### PR TITLE
feat: add bootstrap installer with auto-detect and quick install

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,8 +710,18 @@ Coco alongside the frameworks it builds on:
 
 <sub>If Coco saves you time, consider <a href="https://github.com/rkz91/coco">starring the repo</a>. We also encourage starring <a href="https://github.com/obra/superpowers">obra/superpowers</a> and <a href="https://github.com/gsd-build/get-shit-done">gsd-build/get-shit-done</a> — the frameworks Coco stands on.</sub>
 
----
+<h2>⚡ Quickest Install</h2>
 
+<p>Run this one-liner to install Coco:</p>
+
+<pre><code>curl -fsSL https://raw.githubusercontent.com/rkz91/coco/main/bin/coco-bootstrap.sh | bash</code></pre>
+
+<p>This script will:</p>
+<ul>
+  <li>Automatically detect your AI tool (Claude, Cursor, Codex, or generic)</li>
+  <li>Install Coco to <code>~/.coco</code> (can override using <code>COCO_DIR</code>)</li>
+  <li>Run setup automatically</li>
+</ul>
 ## Browse the library
 
 [`skills/`](skills/) · [`commands/`](commands/) · [`agents/`](agents/) · [`workflows/`](workflows/) · [`templates/`](templates/) · [`rules/`](rules/) · [`systems/`](systems/) · [`adapters/`](adapters/) · [`docs/`](docs/) · [`examples/`](examples/)

--- a/bin/coco-bootstrap.sh
+++ b/bin/coco-bootstrap.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="https://github.com/rkz91/coco.git"
+INSTALL_DIR="${COCO_DIR:-$HOME/.coco}"
+
+detect_adapter() {
+  if command -v claude >/dev/null 2>&1; then
+    echo "claude"
+  elif command -v cursor >/dev/null 2>&1; then
+    echo "cursor"
+  elif command -v codex >/dev/null 2>&1; then
+    echo "codex"
+  else
+    echo "generic"
+  fi
+}
+
+ADAPTER="${COCO_ADAPTER:-$(detect_adapter)}"
+
+echo "Installing Coco..."
+echo "Adapter: $ADAPTER"
+echo "Install directory: $INSTALL_DIR"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "Error: git is required but not installed."
+  exit 1
+fi
+
+if [ -d "$INSTALL_DIR/.git" ]; then
+  echo "Coco already exists. Updating..."
+  git -C "$INSTALL_DIR" pull
+else
+  echo "Cloning Coco..."
+  rm -rf "$INSTALL_DIR"
+  git clone "$REPO_URL" "$INSTALL_DIR"
+fi
+
+cd "$INSTALL_DIR"
+
+if [ ! -f "install.sh" ]; then
+  echo "Error: install.sh not found."
+  exit 1
+fi
+
+bash install.sh --adapter "$ADAPTER"
+
+echo "Coco installed successfully at $INSTALL_DIR"


### PR DESCRIPTION
Added a bash bootstrap installer that:

- Auto-detects AI tools (Claude, Cursor, Codex, generic)
- Installs Coco to ~/.coco (configurable via COCO_DIR)
- Provides one-line curl install in README

Tested locally on Git Bash (Windows) — working as expected.
