### PR TITLE
fix: handle empty ARGS array in install.sh for bash 3.2 (macOS)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,4 +72,4 @@ ARGS=()
 [[ -n "$DRY_RUN" ]] && ARGS+=("$DRY_RUN")
 [[ -n "$SYSTEMS" ]] && ARGS+=("--systems" "$SYSTEMS")
 
-bash "$ADAPTER_DIR/install.sh" "${ARGS[@]}"
+bash "$ADAPTER_DIR/install.sh" ${ARGS[@]+"${ARGS[@]}"}


### PR DESCRIPTION
## Summary
- `install.sh` fails with `unbound variable` error on macOS (bash 3.2) when run without `--dry-run` or `--systems` flags
- The `ARGS` array stays empty, and `"${ARGS[@]}"` under `set -u` is treated as unbound in bash <4.4
- Fixed by using `${ARGS[@]+"${ARGS[@]}"}` which only expands when the array is non-empty

## Test plan
- [x] Verified `bash install.sh --adapter cursor` succeeds without flags
- [x] Verified `bash install.sh --adapter cursor --dry-run` still works with flags

Made with [Cursor](https://cursor.com)