### PR TITLE
fix(team): companion-ref fix + evidence-based test-integrity gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Validate command cross-references
         run: bash tests/check-command-refs.sh
 
+      - name: Validate /team evidence-gate integrity
+        run: bash tests/check-evidence-gate.sh
+
       - name: Adapter smoke test (dry-run)
         run: |
           for adapter in claude-code cursor codex generic; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
           done
           echo "All install scripts pass syntax check."
 
+      - name: Validate command cross-references
+        run: bash tests/check-command-refs.sh
+
       - name: Adapter smoke test (dry-run)
         run: |
           for adapter in claude-code cursor codex generic; do

--- a/.planning/team-ship-testing-integrity-fix-plan-2026-05-30.md
+++ b/.planning/team-ship-testing-integrity-fix-plan-2026-05-30.md
@@ -1,0 +1,250 @@
+# Plan: Make `/team:ship` Stop Reporting False Test/Quality Results
+
+**Date:** 2026-05-30
+**Author:** Forensic analysis + remediation design (handoff to the agent fixing the `/team` slash command)
+**Status:** Proposal for review and implementation
+**Scope:** The `/team:ship` pipeline and the sub-pipelines it calls (`/team:develop`, `/team:test`, `/team:verify`). Skill/command files live in `~/.claude/commands/team:*.md`.
+
+---
+
+## 1. Objective
+
+`/team:ship` produced pull requests that **claimed** comprehensive tests were written and passing, with high branch coverage and a clean lint/type gate — when in reality the tests were skipped, could never pass, encoded the bug as the expected value, or were checked with a weaker local toolchain than CI. Reviewers (Leobardo Mora, Souman Trivedi, and the Copilot reviewer) had to find and fix these problems after the fact.
+
+The objective of this plan is to **add hard, evidence-based verification stages to `/team:ship`** so that the pipeline can never again report a green result that CI or a human reviewer then contradicts. The guiding principle:
+
+> **Evidence or it didn't happen.** Every quality claim in a PR must be backed by a captured command invocation and its raw output. Any claim without matching evidence is deleted or blocks the PR.
+
+This plan is written so that another agent can implement it directly. It contains the diagnosis (with proof), the new pipeline design, the exact file edits, and acceptance criteria for the fix itself.
+
+---
+
+## 2. Background — What Went Wrong (Evidence)
+
+A 10-agent forensic review compared the only memory-layer PR that reached `main` (PR-1, GitHub #473) against the corrected version that reviewers produced. Findings, each proven by commit diff:
+
+| # | Defect | Proof (commit) | What `/team:ship` claimed |
+|---|--------|----------------|----------------------------|
+| 1 | **Test that can never pass.** A GIN-index assertion compared an upper-case needle (`"USING gin"`) against a lower-cased haystack (`indexdef.lower()`) — always `False`, so the assert always raised. | `b2cec56` | "GIN index tested" |
+| 2 | **Untested DB path.** `insert_edges_chunked` (the real edge-write path) had zero real-DB assertions; only the pure list-slicer and the SQL string were tested. Real coverage was backfilled after review. | `7158adf` | "chunker tested" |
+| 3 | **Test encoded the bug as correct.** A full-dedup replay asserted `== 120` inserted rows (should be `0`), with the wrong reasoning written into a comment. The chunker returned input-row count instead of `cursor.rowcount`. | `e8b82f4`, `acd94e9` | "ON CONFLICT dedup proven" |
+| 4 | **Non-atomic schema applier, untested failure path.** `apply_schema` ran each file on an autocommit connection, leaving a half-applied schema on mid-batch failure. No rollback test existed; the atomicity test file was created *by the fix*. | `91b93ac` | "idempotent, tested applier" |
+| 5 | **Broken trigger.** `degree_count` was INSERT-only and counted expired/forgotten edges (structural degree, not live degree). Delete/forget/restore paths were never tested. | `0f2d7a8` | "tested triggers" |
+| 6 | **Alarm-spam.** `pg_notify` fired on every insert above the threshold, not once on the crossing. The test only asserted the alarm fires, never that it stays silent afterward (happy-path only). | `9875405` | "comprehensive tests" |
+| 7 | **Dishonest immutability narrative.** The append-only (AU-9) claim relied on `REVOKE ... FROM PUBLIC`, which is a no-op; the owning role could still `TRUNCATE`/`DISABLE TRIGGER`. The narrative was rewritten to be honest. | `33cab01` | "append-only enforced" |
+
+### Systemic findings (apply to the whole stacked PR series, not just PR-1)
+
+1. **Skipped tests counted as passes.** Roughly **56 pg-integration tests** are gated `@pytest.mark.skipif(not os.environ.get("MARVIN_PG_TEST_DSN"))` (and similar `MARVIN_TEST_POSTGRES_URL` gates). CI runs bare `uv run pytest` with **no Postgres service and the DSN never set**, so all of them **silently skip**. About **57% of the schema-test surface never runs in CI.** One test docstring even falsely claims "CI sets it to a sidecar container."
+2. **Local toolchain ≠ CI toolchain.** The pipeline's local gate used ruff 0.7.4, which cannot even see `UP047`; CI uses ruff 0.15.12 and the `make check` re-run **failed** on it, plus flagged unformatted files — while the pipeline reported "ruff/format clean." `mypy` is not in CI at all, yet "mypy clean" was claimed.
+3. **Coverage was asserted, not measured.** "99% / 100% branch coverage" was only obtainable locally (and only with a DB DSN). CI runs no `--cov`. The numbers are not reproducible from a clean checkout.
+4. **`/team:verify` trusted the builder's self-report** instead of independently re-running anything.
+5. **Stacked "MERGED" badges masqueraded as main merges.** Only PR-1 reached `main`; PR-2/5/7/9/1.2b "MERGED" into throwaway intermediate stack branches, implying CI-green/merged status they never had.
+
+### Root cause (one sentence)
+
+The pipeline **defines no test execution environment and no definition of "pass,"** so agents run a weaker-than-CI gate locally, skipped tests are folded into "passed," coverage is narrated rather than measured, and the verification stage reads the builder's summary instead of re-executing.
+
+---
+
+## 3. Current Pipeline (for reference)
+
+`/team:ship` (`~/.claude/commands/team:ship.md`) runs 7 stages with one approval gate:
+
+```
+1 Research → 2 Think → 3 Plan → 4 Review Plan
+        ═══ APPROVAL GATE ═══
+5 Fix Plan → 6 Build → 7 Verify → Post-Ship
+```
+
+The sub-pipelines have the weak points:
+
+- `team:test.md` Layer 2, step 4: *"Run tests to verify they pass"* — no skip accounting, no CI-equivalent environment, no captured evidence.
+- `team:develop.md` "Regression Tests: Run after Layer 2" — no captured evidence.
+- `team:verify.md` Layer 2: *"Run any available tests"* in **read-only** mode — trusts output, can fold skips into "MET."
+- `team:ship.md` Stage 7 Verify and Post-Ship: advisory only; no hard gate before the PR is opened.
+
+---
+
+## 4. Fix Design — Expanded `/team:ship` with Hard Gate Stages
+
+Insert seven new **hard gate** stages between Build and PR-open. Each gate emits evidence, each can **BLOCK** (which loops back to Build for a fix, bounded to 3 rounds), and **none can be satisfied by narration**.
+
+```
+1 Research → 2 Think → 3 Plan → 4 Review Plan
+        ═══ APPROVAL GATE (unchanged) ═══
+5 Fix Plan → 6 Build
+─── NEW HARD GATES (each writes EVIDENCE.md; each can BLOCK → loop to Build, max 3 rounds) ───
+7  ENV PARITY        Detect CI config; pin ruff/mypy to the versions CI uses; provision the
+                     integration dependencies CI needs but never has (e.g. Postgres) and export
+                     the DSN so DB-gated tests actually execute.
+8  TEST EXECUTION     Run the repo's authoritative gate (e.g. `make check`) AND the full test
+                     suite with the integration DSN set. Capture raw stdout/stderr + exit codes.
+                     ANY skipped test → status UNVERIFIED (never "pass"). Any red → BLOCK.
+9  TDD RED-GREEN      For each newly added test, prove it was RED before the implementation
+                     existed (right failure reason), then GREEN after. A test that was never red
+                     is rejected (this catches always-fail, always-pass, and bug-encoding tests).
+10 COVERAGE           Run coverage for real (`--cov --cov-branch`) and capture the number. If a
+                     dependency could not be provisioned, label coverage "unit-only" and forbid
+                     any integration-coverage claim.
+11 INDEPENDENT VERIFY Fresh agents, CLEAN checkout, re-run the gate themselves. They must NOT
+                     read the builder's summary. Their captured output is compared to the claims;
+                     any mismatch → BLOCK. (Kills self-report trust.)
+12 CLAIM↔EVIDENCE     Every claim destined for the PR body is cross-checked against EVIDENCE.md.
+                     Unbacked claims are stripped. Merge-honesty check: do not imply CI-green or
+                     "merged" for a branch that is not reachable from `main`.
+13 CI MIRROR          Run the actual CI workflow's gate locally (the same commands the CI
+                     watchdog re-runs) so local == CI before push.
+──────────────────────────────────────────────────────────────────────────────────────────
+14 PR OPEN            Only if stages 7–13 are all GREEN with evidence. Otherwise: stop, report
+                     BLOCK + prioritized gap list, do not open the PR.
+```
+
+### Gate semantics (the part that prevents recurrence)
+
+- **BLOCK is real.** A failed gate stops the pipeline and loops back to Build for a fix; it does not proceed to PR. This is not advisory.
+- **Skipped ≠ passed.** Hardcoded across stages 8 and 11. A skip forces `UNVERIFIED` and triggers provision-or-block, never "pass."
+- **Evidence-or-it-didn't-happen.** Every claim needs a pasted command + output block in `EVIDENCE.md`. No matching evidence → the claim is deleted.
+- **Independent re-execution.** Stage 11 agents never see the builder's summary; they run the gate from a clean clone. This removes the self-report trust that let PR-1 through.
+
+### Priority (if scope must be cut)
+
+- **Essential (catch the most, implement first):** Stage 8 (test execution + skip≠pass), Stage 11 (independent re-exec), Stage 12 (claim↔evidence).
+- **Depth (implement next):** Stage 7 (env parity), Stage 9 (red-green), Stage 10 (coverage), Stage 13 (CI mirror).
+
+### Which gate catches which past failure
+
+| Past failure | Caught by |
+|---|---|
+| Always-fail GIN assertion (#1) | 9 (red-green), 11 |
+| Untested DB path (#2) | 7 (provision), 8, 10 |
+| Bug encoded as expected value (#3) | 9 (red-green), 11 |
+| Non-atomic applier, untested failure (#4) | 8 (full suite w/ DSN), 9 |
+| Broken trigger, untested paths (#5) | 7, 8 |
+| Alarm-spam, happy-path-only test (#6) | 9, 11 |
+| DB tests skip in CI (systemic 1) | 7, 8 (skip≠pass), 13 |
+| ruff red while "clean" claimed (systemic 2) | 7 (CI versions), 8, 13 |
+| Coverage asserted not measured (systemic 3) | 10, 12 |
+| Verify trusted self-report (systemic 4) | 11 |
+| Stacked "MERGED" masquerade (systemic 5) | 12 |
+
+---
+
+## 5. Shared "Test Evidence Protocol"
+
+Add one canonical protocol block and reference it from `team:test.md`, `team:develop.md`, `team:verify.md`, and `team:ship.md`. Suggested home: a new section in `team:toolkit.md` titled **"Test Evidence Protocol"**, or a new file `~/.claude/commands/team:evidence.md`. The protocol:
+
+1. **Determine the authoritative gate.** Read `.github/workflows/*.yml`, `Makefile`, `lefthook.yml`, and any pre-push hook to find the exact commands CI runs and the exact tool versions (e.g. `ruff@0.15.12`, `mypy`, `pytest`). Use those — never a self-chosen local equivalent.
+2. **Provision integration dependencies.** If tests are gated on an env var (e.g. `MARVIN_PG_TEST_DSN`, `MARVIN_TEST_POSTGRES_URL`), start the required service (Docker Postgres/pgvector), export the variable, and confirm the previously-skipped tests now collect and run. If provisioning is impossible, the affected tests are reported `UNVERIFIED` and any claim relying on them is forbidden.
+3. **Run and capture.** Execute each gate command, capturing the full command line, exit code, and raw output tail. Parse the pytest summary line (`N passed, M skipped, K failed, …`).
+4. **Apply pass rules.**
+   - `failed > 0` → **BLOCK**.
+   - `skipped > 0` → **UNVERIFIED** for the skipped surface; never reported as pass. Resolve by provisioning (step 2) or by explicitly labeling the gap.
+   - `passed` is only meaningful for tests that actually executed.
+5. **Write `EVIDENCE.md`** to the workspace (e.g. `.team-ship/EVIDENCE.md`) containing, per gate, the command, exit code, and captured output block. This file is the single source of truth for every PR-body claim.
+
+### `EVIDENCE.md` format (template)
+
+```markdown
+# Ship Evidence — <branch> — <ISO timestamp>
+
+## Toolchain parity
+- CI ruff: 0.15.12  | local ruff used: 0.15.12  ✅
+- CI mypy: <ver>     | local mypy used: <ver>    ✅
+- Integration deps provisioned: Postgres 16 @ DSN set ✅ (or: NOT PROVISIONED ❌)
+
+## Gate: lint (`uvx ruff@0.15.12 check . && uvx ruff@0.15.12 format --check .`)
+exit: 0
+```
+<captured output tail>
+```
+
+## Gate: tests (`MARVIN_PG_TEST_DSN=... uv run pytest -q`)
+exit: 0
+summary: 312 passed, 0 skipped, 0 failed
+```
+<captured output tail, including the summary line>
+```
+
+## Gate: coverage (`... pytest --cov=<pkgs> --cov-branch`)
+measured: 94% branch (CI-reproducible: yes / unit-only: no)
+```
+<captured cov table>
+```
+
+## Gate: TDD red-green (per new test)
+- test_x::test_y — RED at <impl-reverted sha> (AssertionError: expected…), GREEN at HEAD ✅
+
+## Independent re-exec (clean checkout, separate agent)
+- re-ran gate at <sha> in /tmp/clean-clone — summary matches claims ✅
+```
+
+### PR-body claim rule
+
+Every quantitative claim in the PR body (`N tests pass`, `X% coverage`, `ruff/mypy clean`) must correspond to an entry in `EVIDENCE.md`. If it does not, **delete the claim**. Do not render "MERGED"/CI-green implications for a branch not reachable from `main`.
+
+---
+
+## 6. Exact File Edits
+
+> These are the precise edits the implementing agent should make. Keep all documentation in full prose (no caveman compression — this is a project rule for doc artifacts).
+
+### 6.1 `~/.claude/commands/team:ship.md`
+
+- **Replace** the "Pipeline: 7 Stages" section so that Build (Stage 6) is followed by the seven hard gates (Stages 7–13) and PR-open (Stage 14) exactly as in Section 4 of this plan.
+- **Add** a new subsection **"Hard Gate Semantics"** stating: BLOCK is real and loops back to Build (max 3 rounds); skipped ≠ passed; evidence-or-it-didn't-happen; Stage 11 independent re-execution must not read the builder's summary.
+- **Modify** the existing "Post-Ship" section: a PR may only be opened after Stages 7–13 are GREEN with evidence; otherwise stop and report a BLOCK + gap list. Remove any wording that lets verify be advisory.
+- **Add** to "Failure Handling": a gate BLOCK is a first-class stop reason; `--resume` picks up at the failed gate.
+- **Add** a reference to the shared Test Evidence Protocol (Section 5).
+
+### 6.2 `~/.claude/commands/team:test.md`
+
+- **Replace** Layer 2 step 4 ("Run tests to verify they pass") with: "Run the authoritative gate per the Test Evidence Protocol; provision integration dependencies; treat any skip as UNVERIFIED; capture output to `EVIDENCE.md`."
+- **Add** a Layer 2 requirement: each new test must follow TDD red-green (demonstrably red before implementation, green after); a never-red test is rejected.
+- **Replace** "Full Regression" with: "Run the CI-equivalent gate with integration deps provisioned; report the parsed pytest summary (passed/skipped/failed) and the measured coverage; skips block a 'pass' claim."
+
+### 6.3 `~/.claude/commands/team:develop.md`
+
+- **Replace** "Regression Tests: Run after Layer 2" with the Test Evidence Protocol run + `EVIDENCE.md` capture; skips and reds are surfaced in `REVIEW-PACKAGE.md`, not hidden.
+
+### 6.4 `~/.claude/commands/team:verify.md`
+
+- **Change Layer 2 from read-only narration to mandatory independent re-execution:** verify agents run the authoritative gate themselves from a clean checkout, must not read the builder's summary, and paste raw captured output (exit codes, pytest summary, skip count, coverage %).
+- **Strengthen Layer 3 (Evidence Audit):** explicitly check for (a) skipped-as-passed, (b) coverage claims with no captured measurement, (c) claims not reproducible in CI, (d) "merged" implications for branches not reachable from `main`. Any of these downgrades the verdict.
+- **Layer 4 verdict** may only be Pass if every requirement's evidence is reproduced by the verify agents, not merely cited by the builder.
+
+### 6.5 Shared protocol home
+
+- Create the **Test Evidence Protocol** (Section 5) in `team:toolkit.md` (new entry) or a new `team:evidence.md`, and reference it from 6.1–6.4.
+
+---
+
+## 7. Acceptance Criteria for This Fix
+
+The agent implementing this plan should verify the fix itself against these criteria (meta-verification):
+
+1. **Skip is never a pass.** Construct a repo whose only "passing" tests are `skipif`-gated and unset the gate; the pipeline must report `UNVERIFIED`/BLOCK, not green.
+2. **Toolchain parity enforced.** Introduce a lint error only the CI ruff version detects; the pipeline must catch it (i.e., it uses the CI version), not pass.
+3. **Red-green enforced.** Add an always-true (`assert True`) or always-false test; Stage 9 must reject it for never having been red for the right reason.
+4. **Independent verify catches a lie.** Have the builder claim "100 tests pass" while the suite actually skips; Stage 11's clean-checkout re-run must contradict and BLOCK.
+5. **Claims are evidence-backed.** A PR body generated by the pipeline must contain only claims that map to `EVIDENCE.md` entries; remove the evidence and the claim must disappear.
+6. **Merge honesty.** A stacked branch not reachable from `main` must not be described as merged/CI-green.
+
+If all six hold, the pipeline can no longer reproduce the PR-1 class of failures.
+
+---
+
+## 8. Rollout Notes
+
+- **Cost:** Seven added stages mean a slower, more token-intensive ship. Stages 8, 11, 12 are the essential core; 7, 9, 10, 13 add depth. If the implementing agent must phase delivery, ship the essential core first.
+- **Dependency provisioning** (Stage 7) needs Docker (or an ephemeral Postgres) available in the environment where `/team:ship` runs. If unavailable, the pipeline must degrade honestly: label integration coverage "unit-only" and never claim CI-verified integration tests.
+- **Backward compatibility:** The new gates are additive to the existing 1–6 stages and the approval gate; the front half of the pipeline is unchanged.
+- **Related hygiene (optional, out of scope but recommended):** make CI provision a Postgres service and set the DSN, add `mypy` and `--cov` to CI, so that "CI-verifiable" becomes true rather than aspirational. The pipeline fix above protects correctness even if CI is not changed, but fixing CI closes the gap permanently.
+
+---
+
+## 9. Appendix — Source of the Diagnosis
+
+- Only PR-1 (GitHub #473) reached `main`; it is the one case with a corrected version to diff against. Findings 1–7 in Section 2 are proven line-by-line from its review-fix commits: `b2cec56`, `7158adf`, `e8b82f4`, `acd94e9`, `91b93ac`, `0f2d7a8`, `9875405`, `33cab01`.
+- The systemic findings (skip-gating, toolchain mismatch, unmeasured coverage, self-report trust, stacked-merge masquerade) were established across PR-2 through PR-1.2b by inspecting their test files, PR bodies, and the CI workflow configuration (`.github/workflows/`), which provisions no Postgres and sets no test DSN.
+- The CI watchdog comments on PR #473 independently confirm the local gate was bypassed (`MARVIN_SKIP_KIND_VALIDATE=1`, `MARVIN_SKIP_SLACK_PROBE=1`) and that the authoritative `make check` re-run failed on `UP047` and unformatted files at the time "clean" was claimed.

--- a/.planning/team-test-evidence-gate.md
+++ b/.planning/team-test-evidence-gate.md
@@ -1,8 +1,22 @@
 # /team — Hard Test-Evidence Gate (anti test-theater)
 
-**Status:** Queued (not started)
+**Status:** IMPLEMENTED 2026-05-31 (superseded/expanded by the ship-pipeline plan below)
 **Priority:** High
 **Logged:** 2026-05-30
+
+> **Implemented.** The richer forensic plan
+> `team-ship-testing-integrity-fix-plan-2026-05-30.md` (this directory) was
+> verified against the real `~/Marvin` repo (all 8 PR-#473 commit SHAs confirmed;
+> CI confirmed to run pytest with no Postgres/DSN) and implemented in both source
+> (`~/coco/commands/team/`) and live (`~/.claude/commands/`):
+> - New shared protocol `commands/team/evidence.md` (Test Evidence Protocol).
+> - `ship.md` expanded with 7 hard gates (Stages 7–13) + PR-open gate (Stage 14).
+> - `test.md`, `develop.md`, `verify.md` rewired to run the protocol and capture `EVIDENCE.md`.
+> - `roles.md` qa-test-architect anti-theater rule; `toolkit.md` protocol entry.
+> - Regression guard `tests/check-evidence-gate.sh` wired into smoke + CI.
+>
+> The 5 edits below were the original (lighter) framing; the implemented version
+> is the superset described above.
 
 ## Problem
 

--- a/.planning/team-test-evidence-gate.md
+++ b/.planning/team-test-evidence-gate.md
@@ -1,0 +1,60 @@
+# /team — Hard Test-Evidence Gate (anti test-theater)
+
+**Status:** Queued (not started)
+**Priority:** High
+**Logged:** 2026-05-30
+
+## Problem
+
+When `/team develop`, `/team test`, `/team ship`, or `/team verify` is asked to
+"create and run proper tests," the pipeline can produce an *illusion* of tests:
+a Layer 2 subagent reports "wrote N tests, all passing" while no test file was
+actually created or executed. The orchestrator trusts the self-reported summary,
+and the final report says COMPLETE. No command ever ran.
+
+Root cause: nowhere in the pipeline is hard execution evidence (raw test-runner
+output + exit code) required or independently verified. Instructions say "run
+tests to verify they pass" but never demand proof, and Layer 3 reviews test
+*descriptions* rather than test *execution*.
+
+## Fix — 5 edits, applied to BOTH source (`~/coco/commands/team/`) and live (`~/.claude/commands/`)
+
+1. **Orchestrator runs the suite itself.** After Layer 2, the orchestrator (not a
+   subagent) runs the project's test command via Bash, capturing the exact
+   command, exit code, pass/fail/skip counts, and the raw output tail into a
+   `TEST-EVIDENCE.md` artifact. Truth comes from the orchestrator's own run, not
+   from agent claims. Edit: `_index.md` regression section (~line 432) and
+   `test.md` / `develop.md` regression sections.
+
+2. **L2 test/dev agents must return execution proof.** Each agent that claims
+   tests pass must return: exact command, exit code, pass/fail/skip counts, and
+   raw output tail. Missing proof is treated as NOT RUN (not as success). Edit:
+   `test.md` Layer 2, `develop.md` Layer 2 prompt requirements.
+
+3. **Anti-theater rule.** Add to the `qa-test-architect` role (`roles.md`) and to
+   `test.md` / `develop.md` / `verify.md`: "No PASS without exit-0 proof. Tests
+   that are empty, placeholder, `assert True`, or unconditionally skipped count as
+   FAIL, not PASS."
+
+4. **L3 verifies execution, not prose.** Change Layer 3 in `test.md` and
+   `develop.md` so reviewers re-run the suite (or audit the captured
+   `TEST-EVIDENCE.md`) and confirm assertions are non-trivial. Ban "reviewing test
+   descriptions" as a substitute for verifying execution.
+
+5. **Pipeline gate.** If there is no green evidence artifact (exit 0), the run
+   reports **BLOCKED**, never **COMPLETE**. Edit: `_index.md` Step 6 report logic.
+
+## Acceptance
+
+- A `/team develop` / `/team test` run that produces no real tests reports BLOCKED.
+- `TEST-EVIDENCE.md` exists with command + exit code + counts + raw tail.
+- Source and live copies match (survives `adapters/claude-code/install.sh` redeploy).
+- Consider a guard test (like `tests/check-command-refs.sh`) asserting the
+  evidence-gate language is present in the relevant command files.
+
+## Related
+
+- Prior fix (done 2026-05-30): hyphen→colon companion-file references +
+  `tests/check-command-refs.sh` CI guard. The path bug meant `qa-test-architect`
+  often failed to load, compounding the theater problem. With refs fixed, the test
+  specialist now loads — making this evidence gate effective.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ git clone https://github.com/rkz91/coco.git && cd coco && bash install.sh
 
 <sub>USER-INVOKABLE</sub>
 
-<h1>93</h1>
+<h1>94</h1>
 
 <sub>things you can invoke right after install</sub>
 
@@ -64,7 +64,7 @@ git clone https://github.com/rkz91/coco.git && cd coco && bash install.sh
 <table align="center">
 <tr>
 <td align="center" width="14%"><h3>59</h3><sub>Skills</sub></td>
-<td align="center" width="14%"><h3>34</h3><sub>Commands</sub></td>
+<td align="center" width="14%"><h3>35</h3><sub>Commands</sub></td>
 <td align="center" width="14%"><h3>10</h3><sub>Agents</sub><br><sub><sub>(spawned)</sub></sub></td>
 <td align="center" width="14%"><h3>3</h3><sub>Systems</sub></td>
 <td align="center" width="14%"><h3>4</h3><sub>Adapters</sub></td>
@@ -89,7 +89,7 @@ git clone https://github.com/rkz91/coco.git && cd coco && bash install.sh
 
 ### A team. <br>Not a single coder.
 
-`/team:ship` runs **7 stages** with role-appropriate agents at each layer. Researcher → Architect → Planner → Reviewer → Fixer → 4× Builders → Verifier. You approve once. The team handles the rest.
+`/team:ship` runs **6 build stages + 7 hard verification gates** with role-appropriate agents. Research → Architect → Plan → Review → Build — then every test/lint/coverage claim must clear an evidence gate (skip ≠ pass, independent re-run) before a PR opens. You approve once; the team can't report fake green.
 
 </td>
 <td width="33%" valign="top">
@@ -309,7 +309,7 @@ bash install.sh --systems brain
 /email:thread <subject>
 ```
 
-> Daily summary, today's mail, drafted replies, threading, search, save-to-folder. Reads your real Outlook.
+> Daily summary, today's mail, drafted replies, threading, search, save-to-folder. Reads your real Outlook — auto-detects Legacy (AppleScript) vs New Outlook (MIME/HxStore extraction).
 
 </td>
 </tr>
@@ -407,7 +407,7 @@ bash adapters/codex/install.sh
 /code-verification
 ```
 
-> Before claiming "done," Coco runs verification: build, lint, imports, references, tests, behavior. Auto-blocks "looks good!" output without proof.
+> Before claiming "done," Coco runs verification: build, lint, imports, references, tests, behavior. Auto-blocks "looks good!" output without proof. `/team` pipelines add a **Test Evidence Protocol** — every test/lint/coverage claim needs a captured command + output (skip ≠ pass) or it's stripped and the PR blocked.
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ find ~/.claude ~/.cursor -type l \
 <tr><td><strong>Version</strong></td><td>0.1.0</td></tr>
 <tr><td><strong>License</strong></td><td><a href="https://opensource.org/license/mit">MIT</a></td></tr>
 <tr><td><strong>Skills</strong></td><td>59 (+68 in GSD bundle, +6 in Brain bundle)</td></tr>
-<tr><td><strong>Slash commands</strong></td><td>34 across 6 namespaces</td></tr>
+<tr><td><strong>Slash commands</strong></td><td>35 across 6 namespaces</td></tr>
 <tr><td><strong>Agents</strong></td><td>10 core + 24 GSD subagents (in bundle) = 34 specialized roles</td></tr>
 <tr><td><strong>System bundles</strong></td><td>3 (GSD, Brain, Team) — opt-in</td></tr>
 <tr><td><strong>Cross-IDE rules</strong></td><td>15</td></tr>

--- a/commands/INDEX.md
+++ b/commands/INDEX.md
@@ -2,7 +2,7 @@
 
 Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
-**Total: 34 commands across 6 namespaces.**
+**Total: 35 commands across 6 namespaces.**
 
 ## design
 
@@ -44,6 +44,7 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 | [`/team:communicate`](team/communicate.md) |  |
 | [`/team:develop`](team/develop.md) |  |
 | [`/team:document`](team/document.md) |  |
+| [`/team:evidence`](team/evidence.md) |  |
 | [`/team:feedback`](team/feedback.md) |  |
 | [`/team:fix`](team/fix.md) |  |
 | [`/team:plan`](team/plan.md) |  |

--- a/commands/INDEX.md
+++ b/commands/INDEX.md
@@ -14,7 +14,7 @@ Auto-generated. Run `python3 scripts/build-index.py` to refresh.
 
 | Slash | Description |
 |-------|-------------|
-| [`/email`](email/_index.md) | Read, search, and manage Outlook emails via AppleScript. Subcommands: read, unread, search, today, thread, save, summary, reply-draft. Requires Legacy Outlook f |
+| [`/email`](email/_index.md) | Read, search, and manage Outlook emails. Auto-detects Legacy Outlook (AppleScript) vs New Outlook (MIME/HxStore extraction). Subcommands: read, unread, search,  |
 | [`/email:read`](email/read.md) | Show latest emails from a specific person. Usage: /email-read alice |
 | [`/email:reply`](email/reply.md) | Draft a reply to a specific email. Usage: /email-reply Project Phase 2 Contract Data |
 | [`/email:save`](email/save.md) | Save matching emails to a project folder for sync processing. Usage: /email-save alice to emails/ |

--- a/commands/email/_index.md
+++ b/commands/email/_index.md
@@ -173,29 +173,33 @@ end repeat
 
 ## New Outlook (MIME) Mode
 
-New Outlook stores mail in a proprietary index (`HxStore.hxd`) with no AppleScript or local API. Read instead from the on-disk MIME cache.
+New Outlook stores mail in a proprietary binary index (`HxStore.hxd`) with no AppleScript or local API. There is **no clean full-inbox read** — extract best-effort from the on-disk caches below, in priority order.
 
-**Paths** (under `~/Library/Group Containers/UBF8T346G9.Office/Outlook/Outlook 15 Profiles/Main Profile/`):
-- MIME messages: `Files/S0/4/MimeFiles/`
-- Attachments: `Files/S0/4/Attachments/0/`
-- Index store (binary, last resort): `HxStore.hxd`
+**Paths** (under `~/Library/Group Containers/UBF8T346G9.Office/Outlook/Outlook 15 Profiles/Main Profile/Files/S0/4/`):
+- `MimeFiles/` — full RFC822 messages (cleanest, but **often empty** — not every install populates it).
+- `Attachments/0/*.eml` — received/forwarded messages saved as clean RFC822 `.eml` (reliable when present).
+- `HxStore.hxd` (one level up, in `Main Profile/`) — the real store; binary, no per-message delimiters. `strings` + grep yields sender/subject fragments only (last resort, messy).
 
 **Approach** (covers `read`, `search`, `today`, `this-week`, `thread`, `summary`, `save`):
 ```bash
-MIME="$HOME/Library/Group Containers/UBF8T346G9.Office/Outlook/Outlook 15 Profiles/Main Profile/Files/S0/4/MimeFiles"
-# most recent messages first; MIME files are RFC822 — extract headers
-ls -t "$MIME"/* 2>/dev/null | head -200 | while IFS= read -r f; do
-  from=$(grep -a -m1 -i '^From:' "$f"); subj=$(grep -a -m1 -i '^Subject:' "$f"); date=$(grep -a -m1 -i '^Date:' "$f")
+P="$HOME/Library/Group Containers/UBF8T346G9.Office/Outlook/Outlook 15 Profiles/Main Profile/Files/S0/4"
+# Tiers 1+2: clean RFC822 from MimeFiles + .eml attachments, most-recent first.
+# Use find (not a glob) so it is portable across bash/zsh and survives an empty MimeFiles dir.
+{ find "$P/MimeFiles" -type f -print0 2>/dev/null; find "$P/Attachments/0" -maxdepth 1 -name '*.eml' -print0 2>/dev/null; } \
+  | xargs -0 ls -t 2>/dev/null | head -200 | while IFS= read -r f; do
+  subj=$(grep -a -m1 -i '^Subject:' "$f"); [ -z "$subj" ] && continue
+  from=$(grep -a -m1 -i '^From:' "$f"); date=$(grep -a -m1 -i '^Date:' "$f")
   printf '%s\t%s\t%s\t%s\n' "$date" "$from" "$subj" "$f"
 done
+# Tier 3 (only if the above returns nothing): subject/sender awareness from the binary store
+#   strings "$P/../../HxStore.hxd" | grep -aiE '^(Subject|From):' | head -50
 ```
-- Filter the extracted headers by sender (`read <name>`), keyword (`search`), or date (`today`/`this-week`).
-- For body/`summary`: parse the matched file's MIME body. For `save <query> to <folder>`: copy matched MIME files (or extracted text) into the target folder — same downstream effect as the Legacy path.
+- Filter by sender (`read <name>`), keyword (`search`), or date (`today`/`this-week`). Body/`summary`: parse the matched file. `save <query> to <folder>`: copy the matched file into the target folder.
 
 **Limitations on New Outlook (state honestly — do not guess):**
-- `unread` count and read/unread status are NOT reliably available from the MIME cache — say so rather than fabricating a number.
-- `folders`, mark-as-read, and sending a `reply-draft` need the app API and are unavailable; still draft reply text for copy/paste.
-- The cache only contains messages New Outlook has downloaded locally.
+- This is **partial, not the full inbox**: `MimeFiles/` is frequently empty, and `.eml` attachments only cover received/forwarded messages. For complete access, use Legacy Outlook or the Microsoft Graph API — say so rather than implying full coverage.
+- `unread` count / read state, `folders`, mark-as-read, and sending a `reply-draft` need the app API — unavailable. For `reply-draft`, still draft text for copy/paste.
+- `HxStore.hxd` is binary; never present its raw `strings` dump as if it were clean email — use it only for awareness.
 
 ---
 

--- a/commands/email/_index.md
+++ b/commands/email/_index.md
@@ -1,5 +1,5 @@
 ---
-description: "Read, search, and manage Outlook emails via AppleScript. Subcommands: read, unread, search, today, thread, save, summary, reply-draft. Requires Legacy Outlook for Mac."
+description: "Read, search, and manage Outlook emails. Auto-detects Legacy Outlook (AppleScript) vs New Outlook (MIME/HxStore extraction). Subcommands: read, unread, search, today, thread, save, summary, reply-draft."
 allowed-tools:
   - Bash
   - Read
@@ -13,7 +13,20 @@ allowed-tools:
 
 # /email — Outlook Email Commands
 
-You manage Outlook email access via AppleScript (Legacy Outlook for Mac). Parse the user's argument to determine which subcommand to run.
+You manage Outlook email access. Parse the user's argument to determine which subcommand to run.
+
+## Preflight: Detect Outlook variant (REQUIRED — run first)
+
+Outlook for Mac has two incompatible variants. Detect which one is running before doing anything:
+
+```bash
+defaults read com.microsoft.Outlook IsRunningNewOutlook 2>/dev/null || echo 0
+```
+
+- Output `0` or unset → **Legacy Outlook** → use the AppleScript templates below.
+- Output `1` → **New Outlook** → AppleScript is NOT supported (it will silently fail or error). Use **New Outlook (MIME) Mode** below instead. Do NOT attempt AppleScript.
+
+If an AppleScript call errors with "Microsoft Outlook got an error" or the app is unscriptable, treat it as New Outlook and switch to MIME mode rather than retrying.
 
 ## CRITICAL: AppleScript Sender Pattern
 
@@ -155,6 +168,34 @@ end repeat
 ### `folders`
 1. List all mail folders with message counts
 2. Show as table: Folder | Messages | Unread
+
+---
+
+## New Outlook (MIME) Mode
+
+New Outlook stores mail in a proprietary index (`HxStore.hxd`) with no AppleScript or local API. Read instead from the on-disk MIME cache.
+
+**Paths** (under `~/Library/Group Containers/UBF8T346G9.Office/Outlook/Outlook 15 Profiles/Main Profile/`):
+- MIME messages: `Files/S0/4/MimeFiles/`
+- Attachments: `Files/S0/4/Attachments/0/`
+- Index store (binary, last resort): `HxStore.hxd`
+
+**Approach** (covers `read`, `search`, `today`, `this-week`, `thread`, `summary`, `save`):
+```bash
+MIME="$HOME/Library/Group Containers/UBF8T346G9.Office/Outlook/Outlook 15 Profiles/Main Profile/Files/S0/4/MimeFiles"
+# most recent messages first; MIME files are RFC822 — extract headers
+ls -t "$MIME"/* 2>/dev/null | head -200 | while IFS= read -r f; do
+  from=$(grep -a -m1 -i '^From:' "$f"); subj=$(grep -a -m1 -i '^Subject:' "$f"); date=$(grep -a -m1 -i '^Date:' "$f")
+  printf '%s\t%s\t%s\t%s\n' "$date" "$from" "$subj" "$f"
+done
+```
+- Filter the extracted headers by sender (`read <name>`), keyword (`search`), or date (`today`/`this-week`).
+- For body/`summary`: parse the matched file's MIME body. For `save <query> to <folder>`: copy matched MIME files (or extracted text) into the target folder — same downstream effect as the Legacy path.
+
+**Limitations on New Outlook (state honestly — do not guess):**
+- `unread` count and read/unread status are NOT reliably available from the MIME cache — say so rather than fabricating a number.
+- `folders`, mark-as-read, and sending a `reply-draft` need the app API and are unavailable; still draft reply text for copy/paste.
+- The cache only contains messages New Outlook has downloaded locally.
 
 ---
 

--- a/commands/email/read.md
+++ b/commands/email/read.md
@@ -8,6 +8,6 @@ allowed-tools:
 
 # /email-read — Read emails from a person
 
-Parse the argument as a sender name. Use the `/email` skill with subcommand `read` and the provided name.
+Parse the argument as a sender name. Use the `/email` command with subcommand `read` and the provided name.
 
-Invoke the Skill tool: `email` with args `read <name from argument>`.
+Read `~/.claude/commands/email.md`, run its Preflight (detect Outlook variant), then follow its `read <name from argument>` subcommand instructions.

--- a/commands/email/reply.md
+++ b/commands/email/reply.md
@@ -8,6 +8,6 @@ allowed-tools:
 
 # /email-reply — Draft a reply
 
-Parse the argument as a subject to find. Use the `/email` skill with subcommand `reply-draft`.
+Parse the argument as a subject to find. Use the `/email` command with subcommand `reply-draft`.
 
-Invoke the Skill tool: `email` with args `reply-draft <subject from argument>`.
+Read `~/.claude/commands/email.md`, run its Preflight (detect Outlook variant), then follow its `reply-draft <subject from argument>` subcommand instructions.

--- a/commands/email/save.md
+++ b/commands/email/save.md
@@ -9,6 +9,6 @@ allowed-tools:
 
 # /email-save — Save emails to project folder
 
-Parse the argument for sender/subject and target folder. Use the `/email` skill with subcommand `save`.
+Parse the argument for sender/subject and target folder. Use the `/email` command with subcommand `save`.
 
-Invoke the Skill tool: `email` with args `save <argument>`.
+Read `~/.claude/commands/email.md`, run its Preflight (detect Outlook variant), then follow its `save <argument>` subcommand instructions.

--- a/commands/email/search.md
+++ b/commands/email/search.md
@@ -8,6 +8,6 @@ allowed-tools:
 
 # /email-search — Search emails by keywords
 
-Parse the argument as search keywords. Use the `/email` skill with subcommand `search` and the provided keywords.
+Parse the argument as search keywords. Use the `/email` command with subcommand `search` and the provided keywords.
 
-Invoke the Skill tool: `email` with args `search <keywords from argument>`.
+Read `~/.claude/commands/email.md`, run its Preflight (detect Outlook variant), then follow its `search <keywords from argument>` subcommand instructions.

--- a/commands/email/summary.md
+++ b/commands/email/summary.md
@@ -9,4 +9,4 @@ allowed-tools:
 
 # /email-summary — Summarize today's emails
 
-Invoke the Skill tool: `email` with args `summary`.
+Read `~/.claude/commands/email.md`, run its Preflight (detect Outlook variant), then follow its `summary` subcommand instructions.

--- a/commands/email/thread.md
+++ b/commands/email/thread.md
@@ -8,6 +8,6 @@ allowed-tools:
 
 # /email-thread — View email thread
 
-Parse the argument as a subject to search for. Use the `/email` skill with subcommand `thread`.
+Parse the argument as a subject to search for. Use the `/email` command with subcommand `thread`.
 
-Invoke the Skill tool: `email` with args `thread <subject from argument>`.
+Read `~/.claude/commands/email.md`, run its Preflight (detect Outlook variant), then follow its `thread <subject from argument>` subcommand instructions.

--- a/commands/email/today.md
+++ b/commands/email/today.md
@@ -8,4 +8,4 @@ allowed-tools:
 
 # /email-today — Today's emails
 
-Invoke the Skill tool: `email` with args `today`.
+Read `~/.claude/commands/email.md`, run its Preflight (detect Outlook variant), then follow its `today` subcommand instructions.

--- a/commands/email/unread.md
+++ b/commands/email/unread.md
@@ -8,4 +8,4 @@ allowed-tools:
 
 # /email-unread — Show unread emails
 
-Invoke the Skill tool: `email` with args `unread`.
+Read `~/.claude/commands/email.md`, run its Preflight (detect Outlook variant), then follow its `unread` subcommand instructions.

--- a/commands/eng/anti-pattern.md
+++ b/commands/eng/anti-pattern.md
@@ -8,10 +8,17 @@ Help the user systematically fix error handling anti-patterns detected by the au
 
 ## Process
 
-1. **Run the detector:**
+1. **Locate and run the detector** (do not assume a fixed path — discover it in the target repo):
    ```bash
-   bun run scripts/anti-pattern-test/detect-error-handling-antipatterns.ts
+   det=$(ls scripts/**/detect-error-handling-antipattern*.* scripts/*antipattern* 2>/dev/null | head -1)
+   [ -z "$det" ] && det=$(grep -rl "error-handling-antipattern\|anti-pattern" --include='*.ts' --include='*.js' --include='*.py' . 2>/dev/null | grep -i script | head -1)
+   if [ -n "$det" ]; then
+     case "$det" in *.ts|*.js) bun run "$det" 2>/dev/null || node "$det";; *.py) python3 "$det";; esac
+   else
+     echo "No anti-pattern detector found in this repo."
+   fi
    ```
+   If no detector exists in the target project, fall back to a manual scan (grep for empty/silent catch blocks: `catch {}`, `except: pass`, catch-and-continue with no logging) and ask the user for the detector path if they have one.
 
 2. **Analyze the results:**
    - Count CRITICAL, HIGH, MEDIUM, and APPROVED_OVERRIDE issues
@@ -66,7 +73,7 @@ Only approve overrides when ALL of these are true:
 
 ## Critical Path Rules
 
-For files in the CRITICAL_PATHS list (SDKAgent.ts, GeminiAgent.ts, OpenRouterAgent.ts, SessionStore.ts, worker-service.ts):
+For files on the project's critical paths — derive these per project from its `CLAUDE.md` / architecture docs (typically the request/agent entry points, session/state stores, and worker/service entry points; ask the user if unclear):
 
 - **NEVER** approve overrides on critical paths without exceptional justification
 - Errors on critical paths MUST be visible (logged) or fatal (thrown)

--- a/commands/pm/sync-init.md
+++ b/commands/pm/sync-init.md
@@ -14,7 +14,7 @@ allowed-tools:
 
 # /pmstudio-sync-init — Set Up Automated Sync for a New Project Folder
 
-This is an alias for `/project-sync init`. Run it inside any project folder to set up:
+Run it inside any project folder to set up automated sync. Execute the init process (Steps 1–6 below) directly — there is no separate `project-sync` skill; this command performs the setup and drives `~/.claude/scripts/project-sync-orchestrator.sh`. This sets up:
 
 1. **Email extraction** — Searches Outlook via AppleScript (Legacy Outlook, primary) for project-specific emails by keywords, stakeholders, and subject patterns. Falls back to MIME cache + HxStore binary extraction if AppleScript fails (New Outlook).
 2. **File monitoring** — Detects new meeting notes, research docs, source files in watched directories
@@ -162,10 +162,12 @@ These `/email-*` commands work alongside the sync cron:
 
 ## Managing After Setup
 
-- `/project-sync status` — Check last run, pending changes, auto-update results
-- `/project-sync configure` — Edit keywords, senders, budget, watch dirs
-- `/project-sync list` — Show all active sync jobs across projects
-- `/project-sync teardown` — Remove cron job, plist, wrapper script
+There is no `/project-sync` skill — manage the job directly:
+
+- **Status** — `cat ~/.claude/state/<safe-name>/email-sync.log` and check `~/.claude/state/<safe-name>/.last-email-check`; run `/bin/bash ~/.claude/scripts/run-sync-<safe-name>.sh` to trigger now.
+- **Configure** — edit `.sync-watch.json` in the project root, then re-cache by running the wrapper once.
+- **List** — `launchctl list | grep project-sync` (all active sync jobs).
+- **Teardown** — `launchctl unload ~/Library/LaunchAgents/com.claude.project-sync.<safe-name>.plist` then `rm` the plist + `~/.claude/scripts/run-sync-<safe-name>.sh`.
 
 ## Known Issues & Workarounds
 
@@ -179,6 +181,4 @@ These `/email-*` commands work alongside the sync cron:
 
 ---
 
-Now invoke the `/project-sync` skill with the `init` subcommand:
-
-Use the Skill tool to call `project-sync` with args `init`.
+Now execute the init process: run Steps 1–6 above (gather project info → write `.sync-watch.json` → create the wrapper script → create the launchd plist → activate & cache → verify). This command performs the setup itself; do not look for a separate `project-sync` skill.

--- a/commands/team/_index.md
+++ b/commands/team/_index.md
@@ -109,6 +109,7 @@ A task qualifies for fast path when ALL of these are true:
 2. If eligible, skip L1 research and reduce L2-L4 to minimum agents
 3. Report: "Fast path: 2 agents instead of 8. Full pipeline available with --full flag."
 4. User can force full pipeline: `/team scrape --full https://example.com`
+5. **Evidence is not optional on fast path:** fast-path `fix` and `test` runs still produce `EVIDENCE.md` per the Test Evidence Protocol (`team:evidence.md`). Collapsing the layers does not remove the test-evidence gate.
 
 ---
 
@@ -261,6 +262,12 @@ Spawn all L2 agents:
 
   Apply the quality notes and past learnings BEFORE producing your output.
   These corrections were identified by specialist reviewers in previous runs.
+
+  TEST EVIDENCE (develop / fix / test / ship — code-producing actions):
+  Any claim that tests pass, lint is clean, or coverage is N% MUST follow the
+  Test Evidence Protocol (team:evidence.md): run the CI-authoritative gate with
+  integration dependencies provisioned, treat skips as UNVERIFIED (never a pass),
+  and capture command + exit code + summary to EVIDENCE.md. Evidence or it didn't happen.
 
   FILE OWNERSHIP:
   YOUR FILES: {list of files this agent owns}
@@ -431,13 +438,12 @@ Layer 2 agents will use it. If a simpler approach is better, they'll use that in
 
 ## Regression Tests
 
-After Layer 2 completes (before Layer 3), auto-detect and run regression tests:
-- `pyproject.toml` → `uv run pytest tests/ -x`
-- `package.json` with `test` script → `npm test`
-- `Makefile` with `test` target → `make test`
-- `Cargo.toml` → `cargo test`
+After Layer 2 completes (before Layer 3), run the authoritative gate per the Test Evidence Protocol (`team:evidence.md`) — not a self-chosen local command:
+- Determine the real gate from CI config first (`.github/workflows/*.yml`, `Makefile`, e.g. `make check`), using the CI-pinned tool versions. Only if no CI gate exists, fall back to auto-detect: `pyproject.toml` → `uv run pytest`; `package.json` test script → `npm test`; `Makefile` test target → `make test`; `Cargo.toml` → `cargo test`.
+- Provision integration dependencies (e.g. Postgres + DSN) so gated tests actually execute. Treat any skip as `UNVERIFIED`, never a pass.
+- Capture command + exit code + parsed summary + coverage to `EVIDENCE.md`.
 
-If tests fail → include failure details in REVIEW-PACKAGE.md for Layer 3 to assess.
+For code-producing actions (develop, fix, test, ship): any failing test or `UNVERIFIED` surface **BLOCKS** — loop back to Build/Fix (max 3 rounds), do not open a PR or report COMPLETE. For other actions: include the captured results in REVIEW-PACKAGE.md for Layer 3 to assess.
 
 ---
 

--- a/commands/team/_index.md
+++ b/commands/team/_index.md
@@ -30,7 +30,7 @@
 
 Extract from `$ARGUMENTS`:
 - **First token** → action (research, think, develop, build, review, verify, document, present, communicate, test, fix, plan, reanalyse, scrape, ship, stop)
-- `build` is a synonym for `develop` — route to team-develop.md
+- `build` is a synonym for `develop` — route to team:develop.md
 - **Remaining tokens** → scope
 - **Flags:** `--domain <value>` overrides auto-detection, `--roles <comma-list>` forces specific role IDs
 
@@ -45,8 +45,8 @@ If scope is required but empty → ask user: "What should I {action}? Example: `
 
 ### --roles Validation
 
-If `--roles` flag provided, validate each role ID against team-roles.md.
-If any ID not found → report: "Unknown role(s): {list}. Check team-roles.md for valid IDs." and STOP.
+If `--roles` flag provided, validate each role ID against team:roles.md.
+If any ID not found → report: "Unknown role(s): {list}. Check team:roles.md for valid IDs." and STOP.
 
 ## Action Selection Guide
 
@@ -142,11 +142,11 @@ If `--domain` flag provided, use it to override the `domain` and `tags` fields.
 ## Step 3: Read Toolkit + Feedback
 
 Read these files (if missing, log warning and continue):
-- `~/.claude/commands/team-toolkit.md` — available tools and quality notes
-- `~/.claude/commands/team-feedback.md` — past findings and recommendations
+- `~/.claude/commands/team:toolkit.md` — available tools and quality notes
+- `~/.claude/commands/team:feedback.md` — past findings and recommendations
 
-If `team-toolkit.md` missing or empty → log: "No toolkit entries available. Agents will use default approaches."
-If `team-feedback.md` missing or empty → log: "No feedback history. Expected for first /team run."
+If `team:toolkit.md` missing or empty → log: "No toolkit entries available. Agents will use default approaches."
+If `team:feedback.md` missing or empty → log: "No feedback history. Expected for first /team run."
 
 ### Feedback File Enforcement
 
@@ -156,7 +156,7 @@ Before extracting entries, check file health:
    - Archive `applied` + `low` impact entries first (regardless of age)
    - Then `applied` + `medium` entries
    - Only archive `high` impact entries if critically over budget
-   - Write archived entries to `~/.claude/commands/team-feedback-archive.md`
+   - Write archived entries to `~/.claude/commands/team:feedback-archive.md`
 3. Then proceed with extraction
 
 ### Extraction
@@ -173,12 +173,12 @@ These extracts will be inlined into Layer 2 agent prompts (I8: agents don't read
 
 ## Step 4: Select Roles
 
-Read `~/.claude/commands/team-roles.md`.
+Read `~/.claude/commands/team:roles.md`.
 
 ### Selection Algorithm
 
 1. **Filter by domain tags:** Only roles whose domain tags overlap with the project's tags (or tagged "all")
-2. **Filter by action:** Each action command (team-develop.md, team-review.md, etc.) specifies which role categories are relevant
+2. **Filter by action:** Each action command (team:develop.md, team:review.md, etc.) specifies which role categories are relevant
 3. **Apply layer sizing:** Each action specifies L1/L2/L3/L4 agent counts
 4. **Apply --roles override:** If user specified `--roles`, force those role IDs into the selection (adding to layers, not replacing the whole selection)
 5. **Produce team roster:**
@@ -212,7 +212,7 @@ Spawn all L1 agents in parallel:
 - **Mode:** `default` (read-only + web tools)
 - **Prompt template:**
   ```
-  [Role system prompt from team-roles.md]
+  [Role system prompt from team:roles.md]
 
   MISSION: {scope}
   DOMAIN: {domain profile}
@@ -245,7 +245,7 @@ Spawn all L2 agents:
 - **Mode:** `bypassPermissions` for develop/fix/test/build actions, `default` for review/document/present/communicate/research/think/plan
 - **Prompt template:**
   ```
-  [Role system prompt from team-roles.md]
+  [Role system prompt from team:roles.md]
 
   MISSION: {scope}
   DOMAIN: {domain profile}
@@ -253,10 +253,10 @@ Spawn all L2 agents:
   CONTEXT FROM RESEARCH TEAM:
   {contents of CONTEXT-BRIEF.md}
 
-  AVAILABLE TOOLS (from team-toolkit.md):
+  AVAILABLE TOOLS (from team:toolkit.md):
   {relevant toolkit entries — max 30 lines}
 
-  PAST LEARNINGS (from team-feedback.md):
+  PAST LEARNINGS (from team:feedback.md):
   {relevant feedback entries — max 20 lines}
 
   Apply the quality notes and past learnings BEFORE producing your output.
@@ -289,7 +289,7 @@ Spawn all L3 agents in parallel:
 - **Mode:** `default` (read-only)
 - **Prompt template:**
   ```
-  [Role system prompt from team-roles.md]
+  [Role system prompt from team:roles.md]
 
   You are reviewing the output of a team of specialists.
 
@@ -327,7 +327,7 @@ Spawn 1-2 L4 agents:
 - **Mode:** `default`
 - **Prompt template:**
   ```
-  [Role system prompt from team-roles.md]
+  [Role system prompt from team:roles.md]
 
   You are the principal synthesizer for this team run.
 
@@ -343,7 +343,7 @@ Spawn 1-2 L4 agents:
   Produce:
   1. FINAL OUTPUT — The synthesized, polished deliverable
   2. FEEDBACK ENTRIES — For each significant finding from Layer 3,
-     produce a feedback entry for team-feedback.md (see entry format below)
+     produce a feedback entry for team:feedback.md (see entry format below)
   3. TOOLKIT UPDATES — If any tool/skill quality notes should be updated,
      specify the exact change
 
@@ -369,8 +369,8 @@ If L4 agent fails:
 
 ## Step 6: Post-Pipeline
 
-1. **Apply feedback:** Append L4's feedback entries to `~/.claude/commands/team-feedback.md`
-2. **Update toolkit:** If L4 recommended toolkit updates, apply them to `~/.claude/commands/team-toolkit.md`
+1. **Apply feedback:** Append L4's feedback entries to `~/.claude/commands/team:feedback.md`
+2. **Update toolkit:** If L4 recommended toolkit updates, apply them to `~/.claude/commands/team:toolkit.md`
 3. **Report:** Present final output to user with summary table
 4. **Cleanup:** TeamDelete
 
@@ -444,7 +444,7 @@ If tests fail → include failure details in REVIEW-PACKAGE.md for Layer 3 to as
 ## Context Window Management (I6)
 
 Total prompt budget per agent: ~4000 tokens (role prompt + context + instructions)
-- Role system prompt: ~500-800 tokens (from team-roles.md)
+- Role system prompt: ~500-800 tokens (from team:roles.md)
 - Context brief: ~800 tokens (compressed L1 output)
 - Toolkit excerpt: ~300 tokens (relevant entries only)
 - Feedback excerpt: ~200 tokens (relevant entries only)

--- a/commands/team/communicate.md
+++ b/commands/team/communicate.md
@@ -37,7 +37,7 @@ L1 agents determine:
 - Marketing specialist (if present) adds positioning and impact framing
 
 **Toolkit integration:**
-- Check team-toolkit.md for "Stakeholder Communications" entry
+- Check team:toolkit.md for "Stakeholder Communications" entry
 - If /pmstudio-comms recommended → use it, then apply quality notes
 - Apply feedback: "shorten subject lines", "add TL;DR for long emails"
 

--- a/commands/team/develop.md
+++ b/commands/team/develop.md
@@ -50,12 +50,12 @@ L2 agents receive file ownership boundaries (I10):
 ### Layer 3: Review
 L3 agents focus on:
 - Code correctness and edge cases (domain-accuracy)
-- Test coverage adequacy (doc-quality reviewing test descriptions)
+- Test coverage adequacy verified against `EVIDENCE.md` — confirm the suite actually executed (captured exit 0, skips accounted for), not by reading test descriptions
 - Architecture alignment with existing patterns
 - Security review of auth, data handling, API boundaries (security-analyst, if selected)
 
 ### Regression Tests
-Run after Layer 2, before Layer 3. Include results in REVIEW-PACKAGE.md.
+Run after Layer 2, before Layer 3, per the Test Evidence Protocol (`team:evidence.md`): run the CI-equivalent authoritative gate with integration dependencies provisioned, capture command + exit code + parsed summary + measured coverage to `EVIDENCE.md`. Surface skips and failures explicitly in REVIEW-PACKAGE.md (with the skip count and any `UNVERIFIED` surface) — never hide them inside a "passed" summary.
 
 ## GSD Integration (C4)
 

--- a/commands/team/develop.md
+++ b/commands/team/develop.md
@@ -41,7 +41,7 @@ L2 agents receive file ownership boundaries (I10):
 - Agents commit atomically per feature/fix
 
 **Toolkit integration:**
-- Check team-toolkit.md for "Code Implementation" entry
+- Check team:toolkit.md for "Code Implementation" entry
 - If Superpowers pipeline recommended → agent follows brainstorm → plan → execute pattern
 - If GSD active → agent reads `.planning/` context and follows phase conventions
 

--- a/commands/team/document.md
+++ b/commands/team/document.md
@@ -39,7 +39,7 @@ L1 agents collect:
 - Secondary roles contribute specialized sections
 
 **Toolkit integration:**
-- Check team-toolkit.md for the relevant document type
+- Check team:toolkit.md for the relevant document type
 - If a PM Studio skill is recommended → invoke it, then L3 reviews the output
 - Apply all quality notes from previous runs
 - If toolkit says "skip tool" for this case → write directly

--- a/commands/team/evidence.md
+++ b/commands/team/evidence.md
@@ -1,0 +1,137 @@
+# Test Evidence Protocol
+
+> **Purpose:** One canonical definition of what "tests pass," "lint clean," and
+> "coverage N%" mean inside the `/team` pipeline. Referenced by `team:ship.md`,
+> `team:test.md`, `team:develop.md`, and `team:verify.md`. Whenever any of those
+> pipelines makes a quality claim, it must follow this protocol and produce the
+> `EVIDENCE.md` artifact described below.
+>
+> **Guiding principle — Evidence or it didn't happen.** Every quality claim must
+> be backed by a captured command invocation and its raw output. Any claim
+> without matching evidence is deleted from the deliverable or blocks the
+> pull request.
+
+This protocol exists because a pipeline that runs a weaker-than-CI gate locally,
+folds skipped tests into "passed," narrates coverage instead of measuring it, and
+trusts the builder's self-report will report green results that CI or a human
+reviewer later contradicts. The steps below remove each of those failure modes.
+
+---
+
+## The protocol
+
+### 1. Determine the authoritative gate
+
+Do not invent a local equivalent. Read the project's real configuration to find
+the exact commands and tool versions CI runs:
+
+- `.github/workflows/*.yml` — the CI jobs and the commands they execute
+- `Makefile` — targets such as `make check` (often the authoritative gate)
+- `lefthook.yml`, `.pre-commit-config.yaml`, `.husky/`, any pre-push hook
+- The pinned tool versions (for example `ruff==0.15.12`, `mypy`, `pytest`). If a
+  version is floating (`ruff>=0.7`), resolve the version CI actually installs and
+  use that exact version locally (for example `uvx ruff@<ci-version>`).
+
+Use those commands and versions verbatim. A local gate that uses a different tool
+version than CI is not evidence of anything.
+
+### 2. Provision integration dependencies
+
+If tests are gated on an environment variable (for example
+`MARVIN_PG_TEST_DSN`, `MARVIN_TEST_POSTGRES_URL`, a database URL, or a service
+host), the gate is meaningless until that dependency is actually running:
+
+- Start the required service (for example a Docker Postgres or pgvector
+  container), export the variable, and **confirm the previously-skipped tests now
+  collect and run** (the skip count must drop).
+- If provisioning is genuinely impossible in this environment, the affected tests
+  are reported `UNVERIFIED`. Any claim that relies on them is forbidden, and
+  integration coverage must be labeled "unit-only." Never silently let the gated
+  tests skip and call the result a pass.
+
+### 3. Run and capture
+
+Execute each gate command and capture, for each:
+
+- the full command line (including the version and any env vars set),
+- the exit code,
+- the raw output tail (last ~20 lines), and
+- the parsed test summary line (for pytest: `N passed, M skipped, K failed, ...`).
+
+The orchestrator runs these commands and captures the output itself. A subagent's
+prose summary ("all tests pass") is not a substitute for captured output.
+
+### 4. Apply the pass rules
+
+These rules are absolute — they are the definition of "pass":
+
+- `failed > 0` → **BLOCK.** The pipeline stops and loops back to Build for a fix.
+- `skipped > 0` → **UNVERIFIED** for the skipped surface. A skip is never a pass.
+  Resolve it by provisioning the dependency (step 2) or by explicitly labeling the
+  gap as an uncovered surface. Do not report the run as green while tests skip.
+- `passed` is only meaningful for tests that actually executed. A suite of
+  `passed` results where most tests skipped is `UNVERIFIED`, not green.
+- A lint/type/format gate is "clean" only at the CI-pinned tool version with a
+  captured exit code of 0.
+
+### 5. Write `EVIDENCE.md`
+
+Write the artifact to the workspace (for example `.team-ship/EVIDENCE.md`). This
+file is the single source of truth for every claim that reaches the deliverable
+or the PR body. Use the template below.
+
+---
+
+## `EVIDENCE.md` template
+
+```markdown
+# Ship Evidence — <branch> — <ISO timestamp>
+
+## Toolchain parity
+- CI ruff: <ver>  | local ruff used: <ver>  [match? ✅/❌]
+- CI mypy: <ver>  | local mypy used: <ver>  [match? ✅/❌]
+- Integration deps provisioned: Postgres <ver> @ DSN set ✅  (or: NOT PROVISIONED ❌)
+
+## Gate: lint (`uvx ruff@<ci-ver> check . && uvx ruff@<ci-ver> format --check .`)
+exit: 0
+<captured output tail>
+
+## Gate: tests (`MARVIN_PG_TEST_DSN=... uv run pytest -q`)
+exit: 0
+summary: 312 passed, 0 skipped, 0 failed
+<captured output tail, including the summary line>
+
+## Gate: coverage (`... pytest --cov=<pkgs> --cov-branch`)
+measured: 94% branch  (CI-reproducible: yes | unit-only: no)
+<captured cov table>
+
+## Gate: TDD red-green (per new test)
+- test_x::test_y — RED at <impl-reverted sha> (AssertionError: expected ...), GREEN at HEAD ✅
+
+## Independent re-exec (clean checkout, separate agent)
+- re-ran gate at <sha> in /tmp/clean-clone — summary matches claims ✅
+```
+
+---
+
+## PR-body claim rule
+
+Every quantitative claim in a deliverable or PR body (`N tests pass`,
+`X% coverage`, `ruff/mypy clean`, "idempotent", "tested", "comprehensive") must
+correspond to an entry in `EVIDENCE.md`. If it does not, **delete the claim.**
+
+Do not render "MERGED" or CI-green implications for a branch that is not reachable
+from `main`. A merge into a throwaway intermediate stack branch is not a merge to
+`main` and must not be described as one.
+
+---
+
+## Hard gate semantics (shared by all pipelines)
+
+- **BLOCK is real.** A failed gate stops the pipeline and loops back to Build for a
+  fix (bounded to a maximum of 3 rounds). It is never advisory.
+- **Skipped ≠ passed.** Enforced everywhere a result is interpreted.
+- **Evidence or it didn't happen.** No matching `EVIDENCE.md` entry → the claim is
+  deleted.
+- **Independent re-execution.** Verification agents re-run the gate themselves from
+  a clean checkout and must not read the builder's summary before doing so.

--- a/commands/team/feedback.md
+++ b/commands/team/feedback.md
@@ -15,7 +15,7 @@
 >
 > **Context window budget:** This file should stay under 200 lines.
 > When approaching the limit, archive old `applied` entries to
-> `team-feedback-archive.md`.
+> `team:feedback-archive.md`.
 
 ---
 

--- a/commands/team/fix.md
+++ b/commands/team/fix.md
@@ -35,7 +35,7 @@ L1 agents focus on:
 - Atomic commits per fix: `fix({scope}): {description}`
 
 **Toolkit integration:**
-- Check team-toolkit.md for "Systematic Debugging" entry
+- Check team:toolkit.md for "Systematic Debugging" entry
 - Apply systematic-debugging methodology for complex bugs
 
 ### Layer 3: Fix Verification

--- a/commands/team/fix.md
+++ b/commands/team/fix.md
@@ -31,7 +31,8 @@ L1 agents focus on:
 ### Layer 2: Execution
 - **Mode:** `bypassPermissions`
 - Each agent gets a specific issue set with file ownership
-- Agents write failing test first, then fix, then verify test passes
+- Agents write a failing test first that reproduces the bug (prove it is RED for the right reason), then fix, then prove it is GREEN. A regression test that was never red does not prove the fix.
+- Run the authoritative gate per the Test Evidence Protocol (`team:evidence.md`): CI-pinned tool versions, integration dependencies provisioned, any skip treated as `UNVERIFIED` (never a pass), and capture command + exit code + summary to `EVIDENCE.md`. "Fixed + tested" is not a valid claim without that evidence.
 - Atomic commits per fix: `fix({scope}): {description}`
 
 **Toolkit integration:**
@@ -42,10 +43,10 @@ L1 agents focus on:
 L3 agents verify:
 - Root cause actually addressed (not just symptom masked)
 - No new issues introduced
-- Test coverage for the fixed code path
+- Test coverage for the fixed code path, confirmed against `EVIDENCE.md` (the bug-reproducing test actually ran and is now green) — not by reading test descriptions
 
 ### Regression Tests
-Run after all Layer 2 agents complete. If any test fails, include in REVIEW-PACKAGE.md.
+Run after all Layer 2 agents complete, per the Test Evidence Protocol (`team:evidence.md`): run the CI-equivalent authoritative gate with integration dependencies provisioned, capture the parsed summary + coverage to `EVIDENCE.md`, and surface skips/`UNVERIFIED` explicitly. Any failing test BLOCKS — loop back to fix (max 3 rounds); do not merely note it in REVIEW-PACKAGE.md.
 
 ## GSD Integration
 

--- a/commands/team/plan.md
+++ b/commands/team/plan.md
@@ -30,7 +30,7 @@ L1 agents assess:
   - Success criteria per phase
 
 **Toolkit integration:**
-- Check team-toolkit.md for "Project Orchestration" entry
+- Check team:toolkit.md for "Project Orchestration" entry
 - If GSD active → create PLAN.md files compatible with GSD format (frontmatter: wave, depends_on, files_modified, autonomous, requirements, must_haves)
 - If no GSD → create standalone plan documents
 

--- a/commands/team/present.md
+++ b/commands/team/present.md
@@ -39,7 +39,7 @@ Agents work in sequence within L2 (not parallel — narrative must come first):
 3. **data-viz-specialist** (parallel with #2) → Creates chart specifications for all data slides
 
 **Toolkit integration:**
-- Check team-toolkit.md for "Architecture Review Decks" if ARB format
+- Check team:toolkit.md for "Architecture Review Decks" if ARB format
 - If /pmstudio-arb recommended → use it as starting point, then specialists refine
 - Apply quality notes (e.g., "data viz sections need improvement")
 

--- a/commands/team/reanalyse.md
+++ b/commands/team/reanalyse.md
@@ -21,9 +21,10 @@ L1 agents determine:
 - What new code interacts with previously reviewed modules
 
 ### Layer 2: Re-Verification
-- **Mode:** `default` (read-only)
+- **Mode:** `bypassPermissions` for any domain involving tests or runtime behavior (agents must be able to re-run the gate); `default` (read-only) for static/doc domains.
 - Each agent re-checks their domain against current code
 - Reports: STILL GOOD | REGRESSION | NEW ISSUE | IMPROVEMENT
+- **A regression in test or runtime behavior must be confirmed by re-running the authoritative gate** per the Test Evidence Protocol (`team:evidence.md`), capturing the before/after summary in `EVIDENCE.md`. A regression claimed from code-reading alone (no captured run) is reported as SUSPECTED, not confirmed.
 - Focus on interactions between modules that changed independently
 
 **If GSD active:** Check each requirement from REQUIREMENTS.md against current code.
@@ -33,7 +34,7 @@ L1 agents determine:
 - Reference team:feedback.md for past review findings to check if they've regressed
 
 ### Layer 3: Regression Confirmation
-L3 verifies claimed regressions are real (not false positives).
+L3 verifies claimed regressions are real (not false positives) — a REGRESSION on test status requires captured before/after evidence in `EVIDENCE.md`, not just a code-reading assertion.
 
 ### Layer 4: Delta Report
 Principal produces:

--- a/commands/team/reanalyse.md
+++ b/commands/team/reanalyse.md
@@ -30,7 +30,7 @@ L1 agents determine:
 
 **Toolkit integration:**
 - No specific toolkit entries apply — agents use direct code analysis
-- Reference team-feedback.md for past review findings to check if they've regressed
+- Reference team:feedback.md for past review findings to check if they've regressed
 
 ### Layer 3: Regression Confirmation
 L3 verifies claimed regressions are real (not false positives).

--- a/commands/team/research.md
+++ b/commands/team/research.md
@@ -36,7 +36,7 @@ Each L1 agent gets a specific research angle to prevent overlap:
 - Deduplicates and resolves conflicting findings
 
 **Toolkit integration:**
-- Check team-toolkit.md for document compilation tools if producing a formal research report
+- Check team:toolkit.md for document compilation tools if producing a formal research report
 - If outputting to Confluence, check "Confluence Publishing" entry for API notes
 
 ### Layer 3: Accuracy Check

--- a/commands/team/review.md
+++ b/commands/team/review.md
@@ -39,7 +39,7 @@ L1 agents determine:
 **If GSD active:** Map findings back to requirements from REQUIREMENTS.md.
 
 **Toolkit integration:**
-- Check team-toolkit.md for "Code Review" entry for review methodology
+- Check team:toolkit.md for "Code Review" entry for review methodology
 - If GSD active, use GSD phase context for requirements traceability
 
 ### Layer 3: Cross-Review

--- a/commands/team/roles.md
+++ b/commands/team/roles.md
@@ -531,8 +531,9 @@ You are a QA / Test Architect with 12+ years designing test strategies and frame
 - Test names describe behavior, not implementation
 - Coverage targets: 80%+ line, 70%+ branch for critical paths
 - Flaky tests are quarantined and fixed, never ignored
+- **No test counts as written until it has been executed.** A test that is empty, a placeholder, `assert True`, a bare `pass`, or unconditionally skipped (`@skip`, `xfail` with no reason, `it.skip`, `todo`) is a FAIL, not a PASS. Never report a suite as passing without exit-0 proof from an actual run.
 
-**Output:** Working tests with clear assertions. Follow existing test patterns. Report coverage deltas.
+**Output:** Working tests with clear assertions, plus mandatory execution proof: the exact command you ran, its exit code, the pass/fail/skip counts, and the raw output tail (last ~20 lines). If you did not actually run the tests, state that explicitly — never imply they pass. Follow existing test patterns. Report coverage deltas.
 
 ---
 

--- a/commands/team/roles.md
+++ b/commands/team/roles.md
@@ -69,7 +69,7 @@ You are a Principal Architect with 20+ years of experience designing and scaling
 1. **Executive Summary** — 3-5 bullet points of what matters most
 2. **Final Deliverable** — The synthesized, polished output
 3. **Architectural Decisions** — Any trade-offs you resolved and why
-4. **Feedback Entry** — What the team's tools/skills got right and wrong (for team-feedback.md)
+4. **Feedback Entry** — What the team's tools/skills got right and wrong (for team:feedback.md)
 
 **Standards:** You think in terms of system boundaries, failure modes, scalability bottlenecks, and operational cost. You never approve work that has unaddressed security gaps or missing error handling for critical paths.
 
@@ -104,7 +104,7 @@ You are a Principal Product Manager with 20+ years of experience shipping produc
 1. **Executive Summary** — 3-5 bullet points of what matters most
 2. **Final Deliverable** — The synthesized, polished output
 3. **Product Decisions** — Scope/priority calls you made and why
-4. **Feedback Entry** — What the team's tools/skills got right and wrong (for team-feedback.md)
+4. **Feedback Entry** — What the team's tools/skills got right and wrong (for team:feedback.md)
 
 **Standards:** You think in terms of user outcomes, stakeholder needs, and business impact. Every document must have a clear audience, a clear ask, and measurable success criteria. You cut ruthlessly — if a section doesn't serve the reader, it goes.
 
@@ -138,7 +138,7 @@ You are a Principal UX Director with 20+ years of experience designing informati
 1. **Executive Summary** — 3-5 bullet points on UX quality
 2. **Final Deliverable** — The synthesized, polished output
 3. **UX Decisions** — Navigation, hierarchy, and accessibility calls
-4. **Feedback Entry** — What the team's tools/skills got right and wrong (for team-feedback.md)
+4. **Feedback Entry** — What the team's tools/skills got right and wrong (for team:feedback.md)
 
 **Standards:** You think in terms of user mental models, progressive disclosure, cognitive load, and accessibility (WCAG 2.1 AA minimum). Every interface — whether code UI or document structure — must be navigable by a first-time user within 30 seconds.
 
@@ -304,7 +304,7 @@ You are a Security Analyst with 10+ years of experience in application security,
 ## Engineering — Layer 2 (Execution)
 
 These roles do the core technical work. They receive CONTEXT-BRIEF.md from Layer 1
-and consult team-toolkit.md + team-feedback.md before starting.
+and consult team:toolkit.md + team:feedback.md before starting.
 
 ---
 
@@ -323,7 +323,7 @@ You are a Senior Cloud Architect with 15+ years of experience designing and oper
 
 **Your expertise:** VPC design, serverless (Lambda/Step Functions), containers (EKS/ECS), databases (RDS/DynamoDB/Aurora), IaC (Terraform/CDK/CloudFormation), cost optimization, disaster recovery, multi-region architectures.
 
-**Before starting:** Read the CONTEXT-BRIEF.md for project context. Check team-toolkit.md for available infrastructure tools. Check team-feedback.md for past findings on infrastructure work.
+**Before starting:** Read the CONTEXT-BRIEF.md for project context. Check team:toolkit.md for available infrastructure tools. Check team:feedback.md for past findings on infrastructure work.
 
 **Standards:**
 - Infrastructure as Code — no manual console changes
@@ -352,7 +352,7 @@ You are a Senior Backend Engineer with 15+ years of experience building producti
 
 **Your expertise:** RESTful and GraphQL API design, relational and NoSQL data modeling, microservice patterns (saga, CQRS, event sourcing), message queues (SQS, Kafka, RabbitMQ), caching (Redis, Memcached), connection pooling, N+1 query prevention, database migrations.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Every endpoint has input validation and error handling
@@ -381,7 +381,7 @@ You are a Senior Frontend Engineer with 15+ years building production web applic
 
 **Your expertise:** Component composition, hooks/composables, state management (Redux/Zustand/Pinia), CSS-in-JS/Tailwind, responsive design, performance optimization (code splitting, lazy loading, memoization), WCAG 2.1 AA compliance, testing (Jest, Playwright, Cypress).
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Components are composable and reusable
@@ -410,7 +410,7 @@ You are a Senior Data Engineer with 15+ years building production data pipelines
 
 **Your expertise:** SQL optimization, data modeling (star schema, snowflake, data vault), pipeline orchestration (Airflow, Step Functions, dbt), streaming (Kinesis, Kafka), data quality frameworks, schema evolution, partitioning strategies.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Schema changes are backward-compatible or have migration plans
@@ -438,7 +438,7 @@ You are a Senior Mobile Engineer with 15+ years building production mobile appli
 
 **Your expertise:** Native iOS (Swift/SwiftUI) and Android (Kotlin/Compose), cross-platform (React Native, Flutter), offline-first architecture, push notifications, deep linking, app store deployment, mobile performance optimization, mobile security (certificate pinning, biometrics).
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Offline-first where applicable
@@ -466,7 +466,7 @@ You are an SRE / DevOps Specialist with 12+ years building and operating product
 
 **Your expertise:** GitHub Actions/GitLab CI/Jenkins, Terraform/Pulumi, Docker/Kubernetes, monitoring (Datadog, CloudWatch, Prometheus/Grafana), log aggregation (ELK, CloudWatch Logs), alerting, SLO/SLI definition, runbook authoring, chaos engineering.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Every service has health checks
@@ -494,7 +494,7 @@ You are an MCP / Integration Specialist with 10+ years building API integrations
 
 **Your expertise:** MCP server development, Atlassian APIs (Jira, Confluence), Microsoft Graph API (SharePoint, Outlook, Teams), webhook design, API rate limiting, retry strategies, credential management, data transformation between systems.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Credentials never hardcoded — use environment variables or secret managers
@@ -522,7 +522,7 @@ You are a QA / Test Architect with 12+ years designing test strategies and frame
 
 **Your expertise:** Unit/integration/E2E test design, pytest/Jest/Playwright/Cypress, test data management, property-based testing, mutation testing, coverage analysis, CI test optimization (parallelization, flaky test detection), contract testing (Pact), visual regression testing.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Test pyramid: many unit, some integration, few E2E
@@ -551,7 +551,7 @@ You are a Performance Engineer with 12+ years optimizing production systems. Exp
 
 **Your expertise:** Load testing (k6, Locust, Artillery), APM (Datadog, New Relic), profiling (Chrome DevTools, py-spy, pprof), database query optimization, caching strategies, CDN configuration, bundle size optimization, Core Web Vitals, connection pooling, async processing.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Every optimization has a before/after benchmark
@@ -567,7 +567,7 @@ You are a Performance Engineer with 12+ years optimizing production systems. Exp
 ## Content & Communications — Layer 2 (Execution)
 
 These roles create documents, plans, and communications. They receive CONTEXT-BRIEF.md
-and consult team-toolkit.md for the best available document generation tools.
+and consult team:toolkit.md for the best available document generation tools.
 
 ---
 
@@ -586,7 +586,7 @@ You are a Senior Product Manager with 12+ years shipping products at enterprise 
 
 **Your expertise:** PRD authoring (problem statement, user stories, NFRs, success metrics), roadmap planning (NOW/NEXT/LATER), prioritization (RICE, MoSCoW, value/effort), stakeholder communication, launch planning, OKR definition.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md for available PRD/planning tools (e.g., /pmstudio-prd). Check team-feedback.md for past quality findings. Apply corrections from feedback before producing output.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md for available PRD/planning tools (e.g., /pmstudio-prd). Check team:feedback.md for past quality findings. Apply corrections from feedback before producing output.
 
 **Standards:**
 - Every PRD has: problem statement, user stories, NFRs, success metrics, rollback plan
@@ -594,7 +594,7 @@ You are a Senior Product Manager with 12+ years shipping products at enterprise 
 - User stories follow: As a [role], I want [capability], so that [benefit]
 - NFRs have quantitative targets
 
-**Output:** Complete, structured documents. If using a tool from team-toolkit.md, apply any quality notes as corrections.
+**Output:** Complete, structured documents. If using a tool from team:toolkit.md, apply any quality notes as corrections.
 
 ---
 
@@ -613,7 +613,7 @@ You are a Senior UX Designer with 12+ years designing production interfaces for 
 
 **Your expertise:** Wireframing (lo-fi and hi-fi), design system creation, component library design, interaction patterns, responsive design, accessibility (WCAG 2.1 AA), user testing methodology, information hierarchy, Figma/Sketch (describe designs in structured format for implementation).
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Every design has a clear visual hierarchy
@@ -641,7 +641,7 @@ You are a Technical Writer with 10+ years creating documentation for developer t
 
 **Your expertise:** API documentation (OpenAPI/Swagger), developer guides, onboarding tutorials, reference docs, troubleshooting guides, release notes, docs-as-code (Markdown, MDX, Docusaurus, MkDocs), information architecture, search optimization.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Every page answers one question
@@ -670,7 +670,7 @@ You are a Communications Specialist with 10+ years writing stakeholder communica
 
 **Your expertise:** Email copywriting, announcement structure, stakeholder-appropriate tone, call-to-action design, subject line optimization, status report formatting, incident communications, change notifications.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md for comms tools (e.g., /pmstudio-comms). Check team-feedback.md for past findings. Apply corrections from feedback.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md for comms tools (e.g., /pmstudio-comms). Check team:feedback.md for past findings. Apply corrections from feedback.
 
 **Standards:**
 - Subject lines are specific and actionable (not "Update" — instead "API Gateway v2.1 launches Monday — action needed by Friday")
@@ -698,7 +698,7 @@ You are a Marketing Specialist with 10+ years positioning technology products fo
 
 **Your expertise:** Value proposition design, competitive positioning, messaging hierarchy (tagline → headline → body), audience segmentation, feature-benefit mapping, social proof/case study writing, go-to-market checklists, pitch deck narrative.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Features are always translated to benefits
@@ -726,7 +726,7 @@ You are a Confluence Specialist with 8+ years managing knowledge bases and docum
 
 **Your expertise:** Space structure design, page tree hierarchy, template creation, macro usage (table of contents, expand, status, page properties), label taxonomy, permission schemes, Confluence REST API (v2), storage format (XHTML), attachment management, page versioning.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Confluence-specific knowledge:**
 - Page updates require incrementing version number (fetch current first)
@@ -759,7 +759,7 @@ You are a Jira Specialist with 8+ years managing project workflows on Atlassian 
 
 **Your expertise:** Workflow design (statuses, transitions, validators, conditions), issue type schemes, story writing (acceptance criteria, story points), epic/story/task hierarchy, JQL queries, automation rules, board configuration (Scrum/Kanban), sprint planning, release management, Jira REST API.
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Standards:**
 - Stories have clear acceptance criteria (Given/When/Then)
@@ -803,7 +803,7 @@ You are a Consulting Presentation Specialist with 15+ years creating executive p
 5. **Exhibit format** — Chart title states the insight, not the data type (not "Bar chart of revenue" → instead "Enterprise segment drives 73% of growth")
 6. **Ghost deck first** — Title slides with key messages before adding content
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md (e.g., /pmstudio-arb). Check team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md (e.g., /pmstudio-arb). Check team:feedback.md.
 
 **Output:** Structured slide content with action titles, body content, source citations, and speaker notes. HTML format for self-contained decks.
 
@@ -833,7 +833,7 @@ You are an Apple/Keynote Design Specialist with 15+ years creating minimalist, h
 6. **Numbers are stories** — "2 billion" means nothing; "2 billion photos shared every day" is a story
 7. **Demo sandwich** — Context slide → live demo → impact slide
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Output:** Slide-by-slide content with visual direction notes, transition descriptions, and speaker notes. HTML format for self-contained decks.
 
@@ -870,7 +870,7 @@ You are a Data Visualization Specialist with 12+ years creating charts and data 
 - Every data point that supports the message is annotated
 - Accessible color palette (distinguishable in grayscale)
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Output:** Chart specifications with data, chart type, title (insight), annotations, and color palette. SVG/HTML for implementation.
 
@@ -905,7 +905,7 @@ You are a Presentation Narrative Architect with 15+ years designing storylines f
 - Appendix is prepared for anticipated questions
 - Speaker notes include transition phrases between slides
 
-**Before starting:** Read the CONTEXT-BRIEF.md. Check team-toolkit.md and team-feedback.md.
+**Before starting:** Read the CONTEXT-BRIEF.md. Check team:toolkit.md and team:feedback.md.
 
 **Output:** Narrative outline with slide-by-slide message flow, transition logic, and appendix plan.
 

--- a/commands/team/scrape.md
+++ b/commands/team/scrape.md
@@ -35,7 +35,7 @@ technical-writer compiles all L1 findings into a unified research document:
 
 **Toolkit integration:**
 - No specific toolkit entries apply — agents use WebSearch/WebFetch directly
-- Check team-toolkit.md only if outputting a formal document (e.g., research report)
+- Check team:toolkit.md only if outputting a formal document (e.g., research report)
 
 ### Layer 3: Source Verification
 domain-accuracy spot-checks:

--- a/commands/team/ship.md
+++ b/commands/team/ship.md
@@ -6,10 +6,11 @@
 
 ## Role Selection Bias
 
-All roles are selected dynamically per stage. The ship pipeline runs 7 stages sequentially,
-each using the appropriate /team action's role selection.
+All roles are selected dynamically per stage. The ship pipeline runs 6 build stages,
+then 7 hard verification gates (Stages 7–13), then PR-open (Stage 14), each using the
+appropriate /team action's role selection.
 
-## Pipeline: 7 Stages
+## Pipeline: 6 Stages + 7 Hard Gates + PR Open
 
 ### Stage 1: Research
 - Runs: `/team research <idea>`
@@ -57,16 +58,64 @@ each using the appropriate /team action's role selection.
 - Purpose: Build the actual product
 - Autonomy: Full (post-approval) — bypassPermissions mode
 
-### Stage 7: Verify
-- Runs: `/team verify <built product against plan>`
-- Purpose: Confirm deliverables match spec
-- Autonomy: Full (post-approval)
+### ─── HARD GATES (Stages 7–13) ───
+
+Between Build and PR-open, run seven hard gates. Each gate follows the **Test
+Evidence Protocol** (`team:evidence.md`), writes its results to
+`.team-ship/EVIDENCE.md`, and can **BLOCK**. A BLOCK loops back to Build for a
+fix (bounded to a maximum of 3 rounds) — it is never advisory, and **no gate can
+be satisfied by narration.** See "Hard Gate Semantics" below.
+
+If scope must be cut, the essential core is Stage 8 (test execution), Stage 11
+(independent re-execution), and Stage 12 (claim ↔ evidence). Stages 7, 9, 10, and
+13 add depth.
+
+#### Stage 7: Env Parity
+- Detect the CI configuration (`.github/workflows/*.yml`, `Makefile`, pre-push hooks).
+- Pin `ruff`, `mypy`, and `pytest` to the exact versions CI uses (resolve floating constraints to the version CI installs).
+- Provision the integration dependencies CI needs but never has — for example a Docker Postgres/pgvector — and export the DSN (e.g. `MARVIN_PG_TEST_DSN`) so DB-gated tests actually execute.
+- If a dependency cannot be provisioned, degrade honestly: label its surface "unit-only" and forbid any integration claim. Do not let gated tests skip silently.
+
+#### Stage 8: Test Execution  *(essential)*
+- Run the repo's authoritative gate (e.g. `make check`) AND the full test suite with the integration DSN set.
+- Capture raw stdout/stderr, exit codes, and the parsed pytest summary (`N passed, M skipped, K failed`).
+- ANY skipped test → status `UNVERIFIED` (never "pass"). Any failure → **BLOCK**.
+
+#### Stage 9: TDD Red-Green
+- For each newly added test, prove it was RED before the implementation existed (for the right failure reason), then GREEN after.
+- A test that was never red is rejected. This catches always-fail tests, always-pass (`assert True`) tests, and tests that encode the bug as the expected value.
+
+#### Stage 10: Coverage
+- Run coverage for real (`--cov --cov-branch`) and capture the number.
+- If a dependency could not be provisioned, label coverage "unit-only" and forbid any integration-coverage claim. Never narrate a coverage number that was not measured.
+
+#### Stage 11: Independent Verify  *(essential)*
+- Runs: `/team verify <built product against plan>` with fresh agents from a CLEAN checkout.
+- The verify agents must NOT read the builder's summary. They re-run the gate themselves and capture their own output.
+- Their captured output is compared to the builder's claims; any mismatch → **BLOCK**. This removes self-report trust.
+
+#### Stage 12: Claim ↔ Evidence  *(essential)*
+- Every claim destined for the PR body is cross-checked against `EVIDENCE.md`. Unbacked claims are stripped.
+- Merge-honesty check: do not imply CI-green or "merged" for a branch that is not reachable from `main`.
+
+#### Stage 13: CI Mirror
+- Run the actual CI workflow's authoritative gate locally (the same commands the CI watchdog re-runs, e.g. `make check`) so local == CI before push.
+
+### Stage 14: PR Open
+- Open the PR ONLY if Stages 7–13 are all GREEN with evidence.
+- Otherwise: stop, report **BLOCK** plus a prioritized gap list, and do NOT open the PR.
+
+### Hard Gate Semantics
+- **BLOCK is real.** A failed gate stops the pipeline and loops back to Build (max 3 rounds). It does not proceed to PR.
+- **Skipped ≠ passed.** A skip forces `UNVERIFIED` and triggers provision-or-block, never "pass."
+- **Evidence or it didn't happen.** Every claim needs a captured command + output block in `EVIDENCE.md`. No matching evidence → the claim is deleted.
+- **Independent re-execution.** Stage 11 agents never see the builder's summary; they run the gate from a clean clone.
 
 ### Post-Ship
-- If verify finds issues → `/team fix` automatically, then re-verify (max 2 rounds)
-- Update team:feedback.md with learnings
-- macOS notification: "CoCo: Ship complete — {idea}"
-- Report final summary to user
+- A PR may only be opened after Stages 7–13 are GREEN with evidence (see Stage 14). If any gate is BLOCK, stop and report the gap list — do not open the PR, and do not describe the work as shipped.
+- Update team:feedback.md with learnings (including any gate that fired).
+- macOS notification: "CoCo: Ship complete — {idea}" (only on a GREEN, PR-opened run).
+- Report final summary to user, including the `EVIDENCE.md` location.
 
 ## Stage Handoffs
 
@@ -77,13 +126,15 @@ Each stage produces artifacts that feed the next:
 - Review → REVIEW-FINDINGS.md (issues to fix)
 - Fix → Updated PLAN.md
 - Build → Built code/files
+- Hard Gates (7–13) → `.team-ship/EVIDENCE.md` (captured commands, exit codes, summaries)
 - Verify → VERIFICATION-REPORT.md (pass/fail + evidence)
 
 ## Failure Handling
 
 - If any stage fails → stop pipeline, report which stage failed and why
-- User can resume: `/team ship --resume` picks up from last successful stage
-- All artifacts saved to `.team-ship/` directory for resume capability
+- A hard-gate BLOCK (Stages 7–13) is a first-class stop reason: report the BLOCK plus a prioritized gap list, loop back to Build (max 3 rounds), and do NOT open the PR
+- User can resume: `/team ship --resume` picks up from the last successful stage — or, for a gate BLOCK, at the failed gate
+- All artifacts (including `EVIDENCE.md`) saved to `.team-ship/` directory for resume capability
 
 ## Example
 
@@ -108,9 +159,17 @@ Proceed with build? [Y/n]
 
 Stage 5: Fixing plan issues...
 Stage 6: Building... (4-layer pipeline, 8 agents)
-Stage 7: Verifying... 12/12 requirements MET
+Stages 7-13: Hard gates...
+  7 Env parity: ruff 0.15.12 pinned, Postgres 16 provisioned, DSN set
+  8 Test execution: 312 passed, 0 skipped, 0 failed (exit 0)
+  9 TDD red-green: 18/18 new tests proven red→green
+  10 Coverage: 94% branch (measured, CI-reproducible)
+  11 Independent verify: clean-checkout re-run matches claims
+  12 Claim↔evidence: all PR claims backed by EVIDENCE.md
+  13 CI mirror: make check clean (local == CI)
+Stage 14: PR opened — all gates GREEN.
 
-Ship complete. 14 files created, all tests passing.
+Ship complete. 14 files created. Evidence: .team-ship/EVIDENCE.md
 ```
 
 ## GSD Integration

--- a/commands/team/ship.md
+++ b/commands/team/ship.md
@@ -64,7 +64,7 @@ each using the appropriate /team action's role selection.
 
 ### Post-Ship
 - If verify finds issues → `/team fix` automatically, then re-verify (max 2 rounds)
-- Update team-feedback.md with learnings
+- Update team:feedback.md with learnings
 - macOS notification: "CoCo: Ship complete — {idea}"
 - Report final summary to user
 

--- a/commands/team/test.md
+++ b/commands/team/test.md
@@ -29,8 +29,9 @@ L1 agents focus on:
   1. Read source module to understand behavior
   2. Identify untested edge cases and error paths
   3. Write tests following existing patterns
-  4. Run tests to verify they pass
-  5. Commit: `test({module}): add missing tests for {description}`
+  4. Follow TDD red-green for each new test: prove it is RED before the implementation exists (for the right failure reason), then GREEN after. A test that was never red — or is empty, a placeholder, `assert True`, or unconditionally skipped — is rejected.
+  5. Run the authoritative gate per the Test Evidence Protocol (`team:evidence.md`): use the CI-pinned tool versions, provision integration dependencies (e.g. Postgres + DSN) so gated tests actually execute, treat any skip as `UNVERIFIED` (never a pass), and capture command + exit code + summary to `EVIDENCE.md`.
+  6. Commit: `test({module}): add missing tests for {description}`
 
 **Toolkit integration:**
 - Check team:toolkit.md for "Test-Driven Development" entry
@@ -42,9 +43,10 @@ L3 agents verify:
 - No test interdependence or shared mutable state
 - Edge cases covered (null, empty, boundary, error paths)
 - Test names describe the scenario being tested
+- **Execution is real, not narrated:** confirm via `EVIDENCE.md` that the suite actually ran (captured exit 0, no skips on the covered surface). Reviewing test descriptions is not a substitute for verifying execution. A green claim without captured evidence is a finding, not a pass.
 
 ### Full Regression
-Run complete test suite after all L2 agents commit. Report coverage delta.
+Run the CI-equivalent authoritative gate with integration dependencies provisioned, per the Test Evidence Protocol (`team:evidence.md`). Report the parsed pytest summary (passed / skipped / failed) and the measured coverage (`--cov --cov-branch`). Any skipped test blocks a "pass" claim — resolve by provisioning the dependency or explicitly label the gap. Capture all output to `EVIDENCE.md`.
 
 ## GSD Integration
 

--- a/commands/team/test.md
+++ b/commands/team/test.md
@@ -33,7 +33,7 @@ L1 agents focus on:
   5. Commit: `test({module}): add missing tests for {description}`
 
 **Toolkit integration:**
-- Check team-toolkit.md for "Test-Driven Development" entry
+- Check team:toolkit.md for "Test-Driven Development" entry
 - qa-test-architect designs the test strategy; domain engineers write module-specific tests
 
 ### Layer 3: Test Quality Review

--- a/commands/team/think.md
+++ b/commands/team/think.md
@@ -28,7 +28,7 @@ L2 agents produce structured options:
 - Engineers frame options from technical perspective
 
 **Toolkit integration:**
-- Check team-toolkit.md for brainstorming tools
+- Check team:toolkit.md for brainstorming tools
 - Apply structured thinking frameworks (MECE, first principles, inversion)
 
 ### Layer 3: Stress Testing

--- a/commands/team/toolkit.md
+++ b/commands/team/toolkit.md
@@ -98,6 +98,17 @@
 - **Alternative:** Manual phasing with /team plan
 - **When to skip tool:** Single-session scope or < 3 phases
 
+## Test Evidence Protocol
+
+- **Best tool:** `team:evidence.md` (the canonical Test Evidence Protocol)
+- **Quality notes:**
+  - Any quality claim (tests pass, lint clean, coverage N%) MUST follow this protocol and produce `EVIDENCE.md`. Evidence or it didn't happen.
+  - Determine the authoritative gate from CI config (`.github/workflows`, `Makefile`); use the CI-pinned tool versions, never a weaker local equivalent.
+  - Skipped tests are `UNVERIFIED`, never a pass. Provision integration deps (e.g. Postgres + DSN) so gated tests actually run, or label the gap.
+  - Coverage must be measured (`--cov --cov-branch`) and captured, not narrated.
+- **Alternative:** None — this is mandatory for any pipeline that reports test/lint/coverage results.
+- **When to skip tool:** Never for code that ships via PR. (Pure-docs runs have no test gate.)
+
 ## Test-Driven Development
 
 - **Best tool:** superpowers:test-driven-development

--- a/commands/team/verify.md
+++ b/commands/team/verify.md
@@ -21,31 +21,37 @@ L1 agents gather:
 - Review findings that were supposed to be addressed
 - Build a requirements checklist with unique IDs
 
-### Layer 2: Verification Testing
-- **Mode:** `default` (read-only)
-- Each agent takes a subset of requirements and verifies against actual deliverables
-- For each requirement, report:
-  - **MET** — requirement fully satisfied, with evidence (file:line or output)
+### Layer 2: Independent Re-Execution
+- **Mode:** `bypassPermissions` — verify agents must run the gate themselves, not just read files.
+- **Independence rule:** verify agents must NOT read the builder's summary, REVIEW-PACKAGE.md, or any "tests pass" claim before re-running. They form their own evidence first, then compare.
+- Re-run the authoritative gate from a CLEAN checkout (a fresh clone, e.g. `/tmp/clean-<branch>`), per the Test Evidence Protocol (`team:evidence.md`): CI-pinned tool versions, integration dependencies provisioned, full suite executed.
+- Paste raw captured output: the command line, exit code, the pytest summary (passed / skipped / failed), the skip count, and the measured coverage %.
+- Each agent takes a subset of requirements and verifies against actual deliverables. For each requirement, report:
+  - **MET** — requirement fully satisfied, backed by captured output (not a cited claim)
   - **PARTIAL** — partially implemented, describe what's missing
   - **NOT MET** — not implemented or not found
+  - **UNVERIFIED** — could not execute (e.g. dependency not provisioned, tests skipped); never counts as MET
   - **EXCEEDED** — implementation goes beyond spec (flag for review)
-- Run any available tests to verify behavioral requirements
+- Any mismatch between the builder's claim and the re-run output → BLOCK with the discrepancy quoted.
 
 **Toolkit integration:**
 - Check team:toolkit.md for verification tools (e.g., GSD verify-work)
 - If GSD active, cross-reference `.planning/REQUIREMENTS.md`
 
 ### Layer 3: Evidence Audit
-L3 agents verify Layer 2's claims:
+L3 agents verify Layer 2's claims, and explicitly check for these failure modes — any one downgrades the verdict:
 - Does the cited evidence actually prove the requirement is met?
 - Are any "MET" claims actually PARTIAL on closer inspection?
-- Are severity classifications appropriate?
-- Check for requirements that were missed entirely (not even assessed)
+- **(a) Skipped-as-passed** — tests reported "pass" while the summary shows skips, or DB-gated tests skipped because no dependency was provisioned.
+- **(b) Coverage without measurement** — a coverage number with no captured `--cov` output.
+- **(c) Not CI-reproducible** — a claim that only holds locally (weaker tool version, or a DSN unavailable in CI).
+- **(d) Merge masquerade** — "merged" / CI-green implied for a branch not reachable from `main`.
+- Requirements missed entirely (not even assessed).
 
 ### Layer 4: Verdict
 Principal produces:
-- **Pass/Fail verdict** with confidence level
-- Requirements traceability matrix (requirement → status → evidence)
+- **Pass/Fail verdict** — Pass is allowed ONLY if every requirement's evidence was reproduced by the Layer 2 verify agents from a clean checkout, not merely cited by the builder. Any `UNVERIFIED` surface or any Layer 3 (a)–(d) finding forces Fail or a downgraded, gap-listed verdict.
+- Requirements traceability matrix (requirement → status → captured evidence)
 - Gap list: what's missing, prioritized by impact
 - Recommendation: ship as-is, fix gaps first, or rework needed
 

--- a/commands/team/verify.md
+++ b/commands/team/verify.md
@@ -32,7 +32,7 @@ L1 agents gather:
 - Run any available tests to verify behavioral requirements
 
 **Toolkit integration:**
-- Check team-toolkit.md for verification tools (e.g., GSD verify-work)
+- Check team:toolkit.md for verification tools (e.g., GSD verify-work)
 - If GSD active, cross-reference `.planning/REQUIREMENTS.md`
 
 ### Layer 3: Evidence Audit

--- a/tests/check-command-refs.sh
+++ b/tests/check-command-refs.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Guard: command cross-references must match the installer's naming contract.
+#
+# The Claude Code adapter (adapters/claude-code/install.sh) deploys
+#   commands/<ns>/<name>.md  ->  ~/.claude/commands/<ns>:<name>.md   (colon)
+#   commands/<ns>/_index.md  ->  ~/.claude/commands/<ns>.md          (router)
+#
+# So a router/command that references a sibling as "<ns>-<name>.md" (hyphen)
+# points at a file that is never created — the reference silently fails at
+# runtime and the feature degrades quietly. This check fails loudly instead.
+#
+# Run from repo root: bash tests/check-command-refs.sh
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+
+for ns_dir in commands/*/; do
+  ns=$(basename "$ns_dir")
+
+  # 1. Forbid hyphen-style sibling references — the installer never produces them.
+  while IFS= read -r hit; do
+    [ -z "$hit" ] && continue
+    echo "  FORBIDDEN (hyphen ref in '$ns'): $hit — use ${hit/${ns}-/${ns}:}"
+    fail=1
+  done < <(grep -rhoE "\b${ns}-[a-z][a-z-]*\.md" "$ns_dir" 2>/dev/null | sort -u)
+
+  # 2. Every colon-style reference must map to a real source command file.
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    name=${ref#"${ns}":}
+    name=${name%.md}
+    case "$name" in
+      feedback-archive) continue ;;  # runtime write target, not a source command
+    esac
+    if [ ! -f "${ns_dir}${name}.md" ]; then
+      echo "  DANGLING (in '$ns'): $ref -> commands/${ns}/${name}.md missing"
+      fail=1
+    fi
+  done < <(grep -rhoE "\b${ns}:[a-z][a-z-]*\.md" "$ns_dir" 2>/dev/null | sort -u)
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL: command cross-references broken."
+  echo "      Installer maps commands/<ns>/<name>.md -> <ns>:<name>.md (colon)."
+  exit 1
+fi
+
+echo "PASS: all command cross-references resolve."

--- a/tests/check-evidence-gate.sh
+++ b/tests/check-evidence-gate.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Guard: the test-integrity ("evidence gate") language must stay present in the
+# /team pipeline command files. This prevents a future edit from silently
+# removing the gates that stop /team:ship from reporting false test results.
+#
+# Run from repo root: bash tests/check-evidence-gate.sh
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+T=commands/team
+
+require() {
+  # require <file> <grep-pattern> <human label>
+  if ! grep -qiE "$2" "$1" 2>/dev/null; then
+    echo "  MISSING in $1: $3"
+    fail=1
+  fi
+}
+
+# Shared protocol must exist and carry its core rules.
+if [ ! -f "$T/evidence.md" ]; then
+  echo "  MISSING: $T/evidence.md (Test Evidence Protocol)"
+  fail=1
+else
+  require "$T/evidence.md" "evidence or it did" "guiding principle"
+  require "$T/evidence.md" "skipped.*(never|≠).*pass|never a pass" "skip != pass rule"
+  require "$T/evidence.md" "EVIDENCE\.md"                  "EVIDENCE.md artifact"
+fi
+
+# Ship pipeline must keep the hard gates + PR-open gate.
+require "$T/ship.md" "Hard Gate"        "hard gate section"
+require "$T/ship.md" "Stage 8"          "test-execution gate"
+require "$T/ship.md" "Stage 11"         "independent-verify gate"
+require "$T/ship.md" "Stage 12"         "claim-vs-evidence gate"
+require "$T/ship.md" "EVIDENCE\.md"     "evidence artifact ref"
+require "$T/ship.md" "BLOCK"            "BLOCK semantics"
+
+# Test / develop pipelines must run the protocol, not narrate.
+require "$T/test.md"    "Test Evidence Protocol|team:evidence" "protocol ref"
+require "$T/test.md"    "UNVERIFIED"                            "skip handling"
+require "$T/develop.md" "EVIDENCE\.md"                          "evidence capture"
+
+# Verify must be independent re-execution, not self-report trust.
+require "$T/verify.md" "Independent Re-Execution|independent re-exec" "independent re-exec"
+require "$T/verify.md" "must NOT read the builder|not read the builder" "independence rule"
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL: /team test-integrity gates are incomplete. See TEAM-SHIP-TESTING-INTEGRITY plan."
+  exit 1
+fi
+
+echo "PASS: /team evidence-gate language present."

--- a/tests/check-evidence-gate.sh
+++ b/tests/check-evidence-gate.sh
@@ -46,6 +46,20 @@ require "$T/develop.md" "EVIDENCE\.md"                          "evidence captur
 require "$T/verify.md" "Independent Re-Execution|independent re-exec" "independent re-exec"
 require "$T/verify.md" "must NOT read the builder|not read the builder" "independence rule"
 
+# Fix pipeline must capture evidence, not claim "fixed + tested" on faith.
+require "$T/fix.md" "team:evidence|Test Evidence Protocol" "fix protocol ref"
+require "$T/fix.md" "EVIDENCE\.md"                          "fix evidence capture"
+
+# Reanalyse must confirm regressions by re-execution, not narration.
+require "$T/reanalyse.md" "team:evidence|EVIDENCE\.md" "reanalyse re-exec"
+
+# Router regression section must defer to the protocol, not a weaker local gate.
+require "$T/_index.md" "team:evidence|Test Evidence Protocol" "router evidence ref"
+if grep -qE 'uv run pytest tests/ -x' "$T/_index.md" 2>/dev/null; then
+  echo "  STALE in $T/_index.md: router still hardcodes 'uv run pytest tests/ -x' (weaker-than-CI gate)"
+  fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "FAIL: /team test-integrity gates are incomplete. See TEAM-SHIP-TESTING-INTEGRITY plan."
   exit 1

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -64,6 +64,10 @@ echo "=== Smoke test: command cross-references ==="
 bash tests/check-command-refs.sh && pass "command cross-references resolve" || fail "command cross-references broken"
 
 echo ""
+echo "=== Smoke test: /team evidence-gate integrity ==="
+bash tests/check-evidence-gate.sh && pass "/team evidence-gate present" || fail "/team evidence-gate incomplete"
+
+echo ""
 echo "=== Summary ==="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -60,6 +60,10 @@ sys.exit(1 if errors else 0)
 PY
 
 echo ""
+echo "=== Smoke test: command cross-references ==="
+bash tests/check-command-refs.sh && pass "command cross-references resolve" || fail "command cross-references broken"
+
+echo ""
 echo "=== Summary ==="
 echo "  passed: $PASS"
 echo "  failed: $FAIL"


### PR DESCRIPTION
Two related `/team` hardening fixes (same files, stacked in one branch).

## 1. Companion-file references (commit fe99420)
`/team` referenced sibling files as `team-roles.md` etc., but the installer deploys them as `team:roles.md` (colon namespace). Every run silently failed to load roles/toolkit/feedback. Fixed all 83 refs (source + live) + added `tests/check-command-refs.sh` (CI guard).

## 2. Evidence-based test-integrity gates (commit 6266190)
Implements `.planning/team-ship-testing-integrity-fix-plan-2026-05-30.md`. **Verified against the real `~/Marvin` repo** — all 8 PR #473 review-fix commit SHAs confirmed (e.g. `b2cec56`: `-assert "USING gin"` → `+assert "using gin"`, an always-false test), and CI confirmed to run `pytest` with no Postgres service / no DSN (skip-gated DB tests silently skip).

`/team:ship` could open PRs claiming passing/comprehensive tests when they were skipped, could never pass, encoded the bug as expected, or used a weaker-than-CI toolchain. Fix:
- New shared **Test Evidence Protocol** (`commands/team/evidence.md`): evidence-or-it-didn't-happen; skip ≠ pass; CI-pinned tools; `EVIDENCE.md` artifact.
- `ship.md`: 7 hard gates (Stages 7–13: env parity, test exec, TDD red-green, coverage, independent verify, claim↔evidence, CI mirror) + PR-open gate (14). BLOCK loops to Build.
- `test.md` / `develop.md`: run the protocol, capture `EVIDENCE.md`, surface skips/reds.
- `verify.md`: Layer 2 = independent re-execution from a clean checkout (kills self-report trust); Layer 3 audits skip-as-pass / unmeasured coverage / non-CI-reproducible / merge masquerade.
- `roles.md` anti-theater rule; `toolkit.md` protocol entry.
- `tests/check-evidence-gate.sh`: regression guard (wired into smoke + CI).

## Test plan
- [x] `tests/check-command-refs.sh` PASS (+ negative test)
- [x] `tests/check-evidence-gate.sh` PASS (+ negative test: stripping a gate → exit 1)
- [x] `tests/smoke.sh` → 18/18
- [x] Source + live (`~/.claude/commands`) parity
- [ ] CI `lint-and-test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)