### PR TITLE
0.1: fix cost/classification write-plane (Track 0 Wave 0.1)

### DIFF
--- a/.team-ship/EVIDENCE.md
+++ b/.team-ship/EVIDENCE.md
@@ -1,0 +1,73 @@
+# Ship Evidence — Track 0 Wave 0.1 (Cost / Classification Spine)
+
+**Date:** 2026-06-01
+**Branch:** `phase/0.1-cost-classification-spine`
+**Scope:** Audit fixes #1 (cost recording), #2 (auto-classifier + content classify), #3 (content-to-action), #11 (chat double cost-record). Plus two latent schema-drift bugs surfaced by TDD.
+
+> Evidence protocol: every claim below has a captured command + output. No claim without evidence.
+
+---
+
+## Stage 9 — TDD Red → Green
+
+New test file `backend/tests/test_wave01_persistence.py` (16 tests) asserts rows actually land.
+
+**RED (before fixes):**
+```
+$ uv run pytest tests/test_wave01_persistence.py -q
+16 failed in 2.57s
+```
+Failures for the right reasons: `TypeError` (upsert kwargs), `CompileError` (phantom columns), `IntegrityError` (wrong conflict target), 2× cost-record assertion, CHECK-not-enforced.
+
+**GREEN (after fixes):**
+```
+$ uv run pytest tests/test_wave01_persistence.py -q
+16 passed in 1.74s
+```
+
+## Stage 8 — Full Suite
+
+```
+$ uv run pytest -q
+378 passed, 9 skipped in 7.57s
+```
+- 0 failures.
+- 9 skipped are PRE-EXISTING integration tests gated on unprovisioned deps (not introduced here). Per protocol they are UNVERIFIED, not "passed". None relate to Wave 0.1.
+
+## Live DB migration (#1) — applied + verified
+
+```
+$ uv run alembic stamp 008_audit_log     # live DB was stamped 005; 006-008 tables already exist via create_all
+$ uv run alembic upgrade head            # runs ONLY 009
+Running upgrade 008_audit_log -> 009_widen_cost_ledger_source
+
+$ sqlite3 ~/.coco/platform.db '.schema cost_ledger' | grep CHECK
+  source TEXT NOT NULL DEFAULT 'agent' CHECK(source IN
+    ('station','chat','think','kh_pipeline','agent','classifier','brain','api_token'))
+
+$ # source='agent' (a real writer the old CHECK rejected):
+INSERT ... source='agent';   -> agent OK
+$ # bogus source still rejected:
+INSERT ... source='bogus';   -> CHECK constraint failed
+```
+Backup taken before migration: `~/.coco/platform.db.pre009.<ts>`.
+
+## Stage 7/13 — Lint (CI mirror, degraded honestly)
+
+- CI gate = `uv run ruff check .` (from `.github/workflows/pr-tests.yml`). `ruff` is not in the synced venv (`uv run ruff` fails to spawn), so mirrored via `uvx ruff@latest check` on the changed files.
+- **My diff is lint-clean:** all 11 reported `B904`/`RUF010` findings are at lines OUTSIDE this change's diff hunks (pre-existing repo debt), and `ruff@latest` may enforce rules not in the repo's pinned `[tool.ruff.lint]` select set. No new lint introduced. Pre-existing repo-wide lint debt is explicitly out of Wave 0.1 scope.
+
+## Bugs fixed (claim ↔ change)
+
+| # | Claim | Change |
+|---|---|---|
+| 1 | cost_ledger accepts real sources; failures are loud | `tables.py` widened `CHECK` + `created_at` server_default; migration 009 rebuilds live table; `record_sdk_cost` swallow → `log.error` |
+| 2 | classifier persistence works + idempotent | `auto_classifier.py` `conflict_cols`→`conflict_columns`, `update_cols`→`update_columns`; `content_classifications.hub_content_id` made `unique=True` (parity) |
+| 2b | content classify/dismiss idempotent | `content.py` conflict target `['id']`→`['hub_content_id']` |
+| 3 | content→action staging + approve works | `action_pipeline.py` dropped phantom cols (`extraction_mode`/`updated_at`/`result_id`→`created_todo_id`); fixed `body`/`raw_text` key read (latent bug: extraction always empty) |
+| 11 | chat SDK cost recorded once | `chat.py` removed redundant `record_sdk_cost` (stream_chat owns it) |
+
+## Latent bugs surfaced by TDD (not in original audit)
+
+1. `content_classifications.hub_content_id` lacked `UNIQUE` in `tables.py` → `ON CONFLICT` failed on fresh DBs (live had it). Fixed (parity).
+2. `process_content` read `.get("body")` but `row._mapping` is keyed `raw_text`/`processed_text` → extraction always empty → zero actions, ever. Fixed.

--- a/backend/alembic/versions/009_widen_cost_ledger_source.py
+++ b/backend/alembic/versions/009_widen_cost_ledger_source.py
@@ -1,0 +1,95 @@
+"""Widen cost_ledger.source CHECK to include all real cost writers.
+
+Revision ID: 009_widen_cost_ledger_source
+Revises: 008_audit_log
+Create Date: 2026-06-01
+
+The legacy cost_ledger CHECK only allowed ('station','chat','think',
+'kh_pipeline'), but the application writes source='agent' (process_manager,
+agent SDK), 'classifier' (auto_classifier), and 'brain' (brain_query). Every
+such insert raised IntegrityError, which record_sdk_cost swallowed -> the
+ledger stayed empty (0 rows) while hub_api_costs grew to ~900.
+
+SQLite cannot ALTER a CHECK in place, so we use the recreate-table pattern:
+create the new table with the widened CHECK, copy all rows, drop the old,
+rename, and recreate the indexes. The widened set mirrors
+``COST_LEDGER_SOURCES`` in db/tables.py (the create_all source of truth).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "009_widen_cost_ledger_source"
+down_revision: Union[str, None] = "008_audit_log"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_COLS = (
+    "id, agent_id, project_id, model, input_tokens, output_tokens, "
+    "cost_usd, source, created_at, node_id"
+)
+
+_WIDE_SOURCES = (
+    "'station','chat','think','kh_pipeline','agent','classifier','brain','api_token'"
+)
+_NARROW_SOURCES = "'station','chat','think','kh_pipeline'"
+
+_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_cost_project ON cost_ledger(project_id)",
+    "CREATE INDEX IF NOT EXISTS idx_cost_time ON cost_ledger(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_cost_ledger_agent ON cost_ledger(agent_id)",
+    "CREATE INDEX IF NOT EXISTS idx_cost_ledger_node ON cost_ledger(node_id)",
+)
+
+
+def _ddl(sources: str) -> str:
+    return f"""
+        CREATE TABLE cost_ledger_new (
+            id TEXT PRIMARY KEY,
+            agent_id TEXT REFERENCES "agents"(id),
+            project_id TEXT,
+            model TEXT NOT NULL,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cost_usd REAL NOT NULL DEFAULT 0.0,
+            source TEXT NOT NULL DEFAULT 'agent' CHECK(source IN ({sources})),
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            node_id TEXT
+        );
+    """
+
+
+def _rebuild(sources: str) -> None:
+    """Recreate cost_ledger with the given CHECK source set.
+
+    Drives DDL+DML through Alembic's bound connection and commits explicitly,
+    matching migration 002 (SQLite non-transactional DDL would otherwise roll
+    back the INSERT/DROP/RENAME). Idempotent against a stray scratch table.
+    """
+    bind = op.get_bind()
+    bind.exec_driver_sql("DROP TABLE IF EXISTS cost_ledger_new")
+    bind.exec_driver_sql(_ddl(sources))
+    bind.exec_driver_sql(
+        f"INSERT INTO cost_ledger_new ({_COLS}) SELECT {_COLS} FROM cost_ledger"
+    )
+    bind.exec_driver_sql("DROP TABLE cost_ledger")
+    bind.exec_driver_sql("ALTER TABLE cost_ledger_new RENAME TO cost_ledger")
+    for stmt in _INDEXES:
+        bind.exec_driver_sql(stmt)
+    bind.commit()
+
+
+def upgrade() -> None:
+    _rebuild(_WIDE_SOURCES)
+
+
+def downgrade() -> None:
+    # Best-effort: rows with the newly-allowed sources would violate the
+    # narrow CHECK, so drop them before reinstating the old constraint.
+    bind = op.get_bind()
+    bind.exec_driver_sql(
+        "DELETE FROM cost_ledger WHERE source NOT IN (" + _NARROW_SOURCES + ")"
+    )
+    bind.commit()
+    _rebuild(_NARROW_SOURCES)

--- a/backend/app/db/tables.py
+++ b/backend/app/db/tables.py
@@ -9,6 +9,7 @@ or columns, update BOTH places.
 """
 
 from sqlalchemy import (
+    CheckConstraint,
     Column,
     Float,
     Integer,
@@ -17,6 +18,13 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     text,
+)
+
+# Canonical cost_ledger.source vocabulary. MUST stay in sync with migration
+# 009 (which rebuilds the legacy CHECK on existing platform.db installs).
+COST_LEDGER_SOURCES = (
+    "station", "chat", "think", "kh_pipeline",
+    "agent", "classifier", "brain", "api_token",
 )
 
 metadata = MetaData()
@@ -145,7 +153,11 @@ cost_ledger = Table(
     Column("output_tokens", Integer, nullable=False, server_default="0"),
     Column("cost_usd", Float, nullable=False, server_default="0.0"),
     Column("source", Text, nullable=False, server_default="agent"),
-    Column("created_at", Text, nullable=False),
+    Column("created_at", Text, nullable=False, server_default=text("(datetime('now'))")),
+    CheckConstraint(
+        "source IN ('station','chat','think','kh_pipeline','agent','classifier','brain','api_token')",
+        name="ck_cost_ledger_source",
+    ),
 )
 
 budgets = Table(
@@ -379,7 +391,7 @@ content_classifications = Table(
     "content_classifications",
     metadata,
     Column("id", Text, primary_key=True),
-    Column("hub_content_id", Text, nullable=False),
+    Column("hub_content_id", Text, nullable=False, unique=True),
     Column("project_id", Text),
     Column("classified_project_id", Text),
     Column("suggested_project_id", Text),
@@ -390,6 +402,22 @@ content_classifications = Table(
     Column("status", Text, server_default="pending"),
     Column("classified_at", Text, nullable=False),
     Column("created_at", Text),
+)
+
+classifier_log = Table(
+    "classifier_log",
+    metadata,
+    Column("id", Text, primary_key=True),
+    Column("hub_content_id", Text, nullable=False),
+    Column("project_id", Text),
+    Column("model", Text, nullable=False),
+    Column("confidence", Float, nullable=False, server_default="0.0"),
+    Column("auto_routed", Integer, nullable=False, server_default="0"),
+    Column("latency_ms", Integer, nullable=False, server_default="0"),
+    Column("method", Text, nullable=False, server_default="rule"),
+    Column("reasoning", Text),
+    Column("error", Text),
+    Column("created_at", Text, nullable=False),
 )
 
 project_overrides = Table(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,6 +87,11 @@ async def lifespan(app: FastAPI):
     log.info("trigger_engine_started")
     _register_si_listeners()
     log.info("self_improve_scheduler_listeners_registered")
+    try:
+        _si_recovered = self_improve_service.recover_interrupted_cycles()
+        log.info("self_improve_cycles_recovered", count=_si_recovered)
+    except Exception as exc:  # never block startup
+        log.warning("self_improve_recovery_failed", error=str(exc))
     hub_sync_task = asyncio.create_task(hub_sync.start())
     log.info("hub_sync_started")
     knowledge_sync_task = asyncio.create_task(knowledge_sync.start())

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -246,12 +246,9 @@ async def _sdk_chat_event_generator(message: str, model: str, system_prompt: str
                 else:
                     _update_session_after_message(session_id)
 
-    if input_tokens or output_tokens:
-        from app.services.agent_sdk_client import record_sdk_cost  # noqa: lazy import (optional dep)
-        record_sdk_cost(
-            model=response_model, input_tokens=input_tokens,
-            output_tokens=output_tokens, source="chat",
-        )
+    # NOTE: cost is recorded inside agent_sdk.stream_chat (via _record_dual,
+    # source="chat"). Do NOT record again here — doing so double-counted every
+    # SDK chat turn (2x cost inflation). stream_chat owns cost recording.
 
     yield {"event": "done", "data": json.dumps({"type": "done", "content": full_response, "session_id": session_id})}
 

--- a/backend/app/routers/content.py
+++ b/backend/app/routers/content.py
@@ -188,8 +188,8 @@ def classify_content(content_id: str, body: ClassifyContentBody):
                         "action": "classify",
                         "classified_at": now(),
                     },
-                    conflict_columns=["id"],
-                    update_columns=["hub_content_id", "project_id", "action"],
+                    conflict_columns=["hub_content_id"],
+                    update_columns=["project_id", "action", "classified_at"],
                 )
             )
 
@@ -220,8 +220,8 @@ def dismiss_content(content_id: str):
                         "action": "dismiss",
                         "classified_at": now(),
                     },
-                    conflict_columns=["id"],
-                    update_columns=["hub_content_id", "action"],
+                    conflict_columns=["hub_content_id"],
+                    update_columns=["action", "classified_at"],
                 )
             )
 

--- a/backend/app/services/action_pipeline.py
+++ b/backend/app/services/action_pipeline.py
@@ -186,8 +186,15 @@ def process_content(content_id: str, mode: str = "regex") -> list[dict]:
         log.warning("action_pipeline_content_not_found", content_id=content_id)
         return []
 
-    row_dict = dict(row._mapping)
-    content_text = row_dict.get("body") or row_dict.get("summary") or ""
+    # row._mapping is keyed by the real column names (raw_text/processed_text),
+    # not the .c.body/.c.summary key aliases — accept either so extraction
+    # actually receives the content. (Reading .get("body") alone always
+    # returned "" and silently produced zero actions.)
+    m = row._mapping
+    content_text = (
+        m.get("body") or m.get("raw_text")
+        or m.get("summary") or m.get("processed_text") or ""
+    )
     if not content_text.strip():
         return []
 
@@ -220,10 +227,8 @@ def process_content(content_id: str, mode: str = "regex") -> list[dict]:
                 "priority": item.get("priority", "medium"),
                 "source_quote": item.get("source_quote"),
                 "confidence": item.get("confidence", 0.5),
-                "extraction_mode": mode,
                 "status": "staged",
                 "created_at": now,
-                "updated_at": now,
             }
             conn.execute(insert(staged_actions).values(**values))
             staged.append(values)
@@ -322,7 +327,7 @@ def approve_action(action_id: str) -> dict | None:
         conn.execute(
             update(staged_actions)
             .where(staged_actions.c.id == action_id)
-            .values(status="approved", result_id=todo_id, updated_at=now)
+            .values(status="approved", created_todo_id=todo_id)
         )
 
     event_bus.emit("actions.approved", {
@@ -333,7 +338,7 @@ def approve_action(action_id: str) -> dict | None:
     event_bus.emit("todo.created", {"id": todo_id, "title": action["title"]})
 
     action["status"] = "approved"
-    action["result_id"] = todo_id
+    action["created_todo_id"] = todo_id
     return action
 
 
@@ -357,7 +362,7 @@ def reject_action(action_id: str) -> dict | None:
         conn.execute(
             update(staged_actions)
             .where(staged_actions.c.id == action_id)
-            .values(status="rejected", updated_at=now)
+            .values(status="rejected")
         )
 
     event_bus.emit("actions.rejected", {"action_id": action_id, "title": action["title"]})

--- a/backend/app/services/agent_sdk_client.py
+++ b/backend/app/services/agent_sdk_client.py
@@ -430,7 +430,10 @@ def record_sdk_cost(
                 )
             )
     except Exception as e:
-        log.warning("record_sdk_cost_failed", error=str(e))
+        # Cost recording is non-fatal to the agent flow, but it must be LOUD:
+        # a swallowed IntegrityError here (e.g. a source value the cost_ledger
+        # CHECK rejected) is exactly how the ledger silently stayed empty.
+        log.error("record_sdk_cost_failed", source=source, model=model, error=str(e))
         return
 
     try:

--- a/backend/app/services/auto_classifier.py
+++ b/backend/app/services/auto_classifier.py
@@ -499,15 +499,15 @@ def _apply_classification(
                         "classified_at": now(),
                         "created_at": now(),
                     },
-                    conflict_cols=["hub_content_id"],
-                    update_cols=[
+                    conflict_columns=["hub_content_id"],
+                    update_columns=[
                         "classified_project_id", "project_id", "confidence",
                         "reasoning", "auto_classified", "status", "action", "classified_at",
                     ],
                 )
             )
     except Exception as e:
-        log.warning("apply_classification_failed", content_id=content_id, error=str(e))
+        log.error("apply_classification_failed", content_id=content_id, error=str(e))
 
 
 def _save_suggestion(content_id: str, project_id: str, confidence: float, reasoning: str):
@@ -529,12 +529,12 @@ def _save_suggestion(content_id: str, project_id: str, confidence: float, reason
                         "classified_at": now(),
                         "created_at": now(),
                     },
-                    conflict_cols=["hub_content_id"],
-                    update_cols=[
+                    conflict_columns=["hub_content_id"],
+                    update_columns=[
                         "classified_project_id", "suggested_project_id", "confidence",
                         "reasoning", "auto_classified", "status", "action", "classified_at",
                     ],
                 )
             )
     except Exception as e:
-        log.warning("save_suggestion_failed", content_id=content_id, error=str(e))
+        log.error("save_suggestion_failed", content_id=content_id, error=str(e))

--- a/backend/app/services/event_bus.py
+++ b/backend/app/services/event_bus.py
@@ -12,7 +12,7 @@ import json
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Callable
 
 import structlog
 from sqlalchemy import delete, insert, select
@@ -42,6 +42,37 @@ class EventBus:
 
     def __init__(self) -> None:
         self._subscribers: list[asyncio.Queue] = []
+        # Synchronous in-process listeners: (event_type | None, callback).
+        # event_type None means "all events". Invoked inside emit().
+        self._listeners: list[tuple[str | None, Callable[[dict], None]]] = []
+
+    # -- synchronous listener API -----------------------------------------
+
+    def on(self, event_type: str | None, callback: Callable[[dict], None]) -> None:
+        """Register a synchronous listener invoked on every matching emit().
+
+        Args:
+            event_type: Exact event type to match, or ``None`` for all events.
+            callback: Called as ``callback(data)`` where ``data`` is the emit
+                payload dict.
+
+        Idempotent: registering the same ``(event_type, callback)`` pair more
+        than once is a no-op, so callers may safely re-run their registration
+        (e.g. repeated app startup in tests or a reload) without stacking
+        duplicate listeners.
+        """
+        for et, cb in self._listeners:
+            if et == event_type and cb == callback:
+                return
+        self._listeners.append((event_type, callback))
+
+    def off(self, event_type: str | None, callback: Callable[[dict], None]) -> None:
+        """Remove a previously registered listener. No-op if not present."""
+        self._listeners = [
+            (et, cb)
+            for et, cb in self._listeners
+            if not (et == event_type and cb == callback)
+        ]
 
     # -- persistence helpers (fire-and-forget, never block emit) ----------
 
@@ -90,6 +121,20 @@ class EventBus:
 
         # Bridge to events.jsonl for CLI visibility
         self._append_jsonl(event_type, data)
+
+        # Notify synchronous in-process listeners. Iterate a snapshot so a
+        # listener that emits re-entrantly (e.g. emits another event) cannot
+        # mutate the list mid-iteration. Listener errors never break emit.
+        for et, cb in list(self._listeners):
+            if et is None or et == event_type:
+                try:
+                    cb(data)
+                except Exception as exc:
+                    log.warning(
+                        "event_listener_error",
+                        event_type=event_type,
+                        error=str(exc),
+                    )
 
     # -- events.jsonl bridge ------------------------------------------------
 

--- a/backend/app/services/self_improve.py
+++ b/backend/app/services/self_improve.py
@@ -256,10 +256,53 @@ def cleanup_stale_worktrees(max_age_hours: int = 24):
 
 
 class SelfImproveService:
+    # Non-terminal states that require a live driving process. The state
+    # machine only advances while a spawned agent is alive and emitting
+    # completion events, so a cycle found in one of these after a restart was
+    # interrupted by a crash/restart and is dead. 'awaiting_approval' is
+    # EXCLUDED — it intentionally waits for a human and survives restarts.
+    _INTERRUPTED_STATES = (
+        "planning", "architecting", "developing", "testing",
+        "reviewing", "documenting", "merging", "integrating",
+    )
+
     def __init__(self):
         self.worktree_mgr = WorktreeManager()
         self._active_cycle_id: str | None = None
         self._lock = threading.Lock()
+
+    def recover_interrupted_cycles(self) -> int:
+        """Fail any cycle left mid-flight by a crash/restart. Returns count.
+
+        Call ONCE at app startup (lifespan), when nothing is driving a cycle.
+        Marks every cycle stuck in a processing state as 'failed' (recording
+        the reason), clears in-memory active state, and releases the lock file
+        so a new cycle can start cleanly. This is what prevents a crashed cycle
+        from wedging in 'planning' forever (the failure mode that left cycle
+        9faac75d stuck for 24 days). Idempotent.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        placeholders = ",".join("?" for _ in self._INTERRUPTED_STATES)
+        with get_db() as db:
+            rows = db.exec_driver_sql(
+                f"SELECT id FROM self_improve_cycles WHERE status IN ({placeholders})",
+                tuple(self._INTERRUPTED_STATES),
+            ).fetchall()
+            ids = [r._mapping["id"] for r in rows]
+            for cid in ids:
+                db.exec_driver_sql(
+                    "UPDATE self_improve_cycles SET status = 'failed', "
+                    "error = COALESCE(NULLIF(error, ''), ?), completed_at = ? "
+                    "WHERE id = ?",
+                    ("Interrupted by restart (no active driver process)", now, cid),
+                )
+        if ids:
+            with self._lock:
+                if self._active_cycle_id in ids:
+                    self._active_cycle_id = None
+            _release_lock()
+            log.info("recovered_interrupted_cycles", count=len(ids), cycle_ids=ids)
+        return len(ids)
 
     # ------------------------------------------------------------------
     # Cycle CRUD
@@ -313,18 +356,32 @@ class SelfImproveService:
             _release_lock()
             raise
 
-        # Spawn PM agent to analyze codebase
-        focus_clause = ""
-        if focus_areas:
-            focus_clause = f"Focus areas: {', '.join(focus_areas)}. "
+        # Spawn PM agent to analyze codebase.
+        #
+        # CRITICAL: everything below runs *after* the lock-guarded try/except
+        # above, so any failure here (prompt build, agent spawn) used to wedge
+        # the cycle in 'planning' forever and leak the lock file with no error
+        # recorded. Guard it: on failure, mark the cycle 'failed' (records the
+        # error) and release the lock via _fail_cycle so the system is left in
+        # a recoverable state and a new cycle can start.
+        try:
+            focus_clause = ""
+            if focus_areas:
+                focus_clause = f"Focus areas: {', '.join(focus_areas)}. "
 
-        prompt = SQUAD_ROLES["pm"]["prompt_template"].format(
-            repo_root=REPO_ROOT,
-            max_improvements=max_improvements,
-            focus_clause=focus_clause,
-        )
+            prompt = SQUAD_ROLES["pm"]["prompt_template"].format(
+                repo_root=REPO_ROOT,
+                max_improvements=max_improvements,
+                focus_clause=focus_clause,
+            )
 
-        self._spawn_squad_agent(cycle_id, "pm", prompt)
+            self._spawn_squad_agent(cycle_id, "pm", prompt)
+        except Exception as e:
+            log.error("start_cycle_spawn_failed", cycle_id=cycle_id, error=str(e))
+            # _fail_cycle records the error, clears _active_cycle_id, and
+            # releases the lock (idempotent if already released).
+            self._fail_cycle(cycle_id, f"Failed to spawn PM agent: {e}")
+            raise
 
         event_bus.emit("self_improve.cycle_started", {
             "cycle_id": cycle_id,
@@ -1378,13 +1435,18 @@ class SelfImproveService:
                 ),
             )
 
-            # Link to cycle
+            # Link to cycle. Both INSERTs share this single get_db()
+            # transaction (conn.begin()): get_db commits on clean exit and
+            # rolls back on exception, so the agents row and its
+            # self_improve_agents link are written atomically — both or
+            # neither. (Previously an explicit db.commit() here made the two
+            # inserts non-atomic and could leave an orphan agents row with no
+            # cycle link.)
             db.exec_driver_sql(
                 "INSERT INTO self_improve_agents (id, cycle_id, improvement_id, agent_id, role, status, started_at, created_at) "
                 "VALUES (?, ?, ?, ?, ?, 'running', ?, ?)",
                 (str(uuid.uuid4()), cycle_id, improvement_id, agent_id, role, now, now),
             )
-            db.commit()
 
         # Check budget before spawning
         if not self._check_budget(cycle_id):
@@ -1442,9 +1504,14 @@ class SelfImproveService:
                 return True
 
             placeholders = ",".join("?" for _ in agent_ids)
+            # NOTE: params MUST be a tuple. Passing the raw list makes
+            # exec_driver_sql treat it as executemany (expecting a list of
+            # tuples/dicts) and raise "List argument must consist only of
+            # tuples or dictionaries" -- which broke the budget check on the
+            # very first agent spawn.
             cost_row = db.exec_driver_sql(
                 f"SELECT COALESCE(SUM(cost_usd), 0.0) as total FROM cost_ledger WHERE agent_id IN ({placeholders})",
-                agent_ids,
+                tuple(agent_ids),
             ).fetchone()
             total_spent = cost_row._mapping["total"] if cost_row else 0.0
 

--- a/backend/app/services/self_improve_scheduler.py
+++ b/backend/app/services/self_improve_scheduler.py
@@ -235,20 +235,11 @@ def on_cycle_completed(data: dict) -> None:
 def register_event_listeners() -> None:
     """Wire up the cycle completion handler to the event bus.
 
-    Called during app startup (lifespan).
+    Called during app startup (lifespan). Idempotent: ``EventBus.on`` dedupes
+    by ``(event_type, callback)``, so repeated startups/reloads do not stack
+    duplicate listeners (previously this monkey-patched ``event_bus.emit`` and
+    re-registration stacked wrappers, double-firing the handler and growing
+    call depth).
     """
-    # The event bus is sync (emit is sync), but we store a reference
-    # for the completion handler.  We hook it by monkey-patching emit
-    # to also call our handler for the specific event type.
-    _original_emit = event_bus.emit
-
-    def _patched_emit(event_type: str, data: dict) -> None:
-        _original_emit(event_type, data)
-        if event_type == "self_improve.cycle_completed":
-            try:
-                on_cycle_completed(data)
-            except Exception as e:
-                log.warning("cycle_completed_listener_error", error=str(e))
-
-    event_bus.emit = _patched_emit  # type: ignore[assignment]
+    event_bus.on("self_improve.cycle_completed", on_cycle_completed)
     log.info("self_improve_scheduler_listeners_registered")

--- a/backend/tests/test_event_bus.py
+++ b/backend/tests/test_event_bus.py
@@ -1,0 +1,126 @@
+"""Regression tests for EventBus synchronous listener API.
+
+Covers the fix for the self-improve scheduler bug where
+``register_event_listeners()`` monkey-patched ``event_bus.emit`` by wrapping
+it, so repeated calls (app restart in tests, reloads) stacked wrappers and
+fired the completion handler multiple times with growing call depth.
+
+The fix replaces monkey-patching with an idempotent ``EventBus.on()`` listener
+registry invoked inside ``emit()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.event_bus import EventBus, event_bus
+from app.services import self_improve_scheduler as sched
+
+
+def _make_bus(monkeypatch) -> EventBus:
+    """Fresh bus with persistence/file bridges stubbed out (pure-unit)."""
+    bus = EventBus()
+    monkeypatch.setattr(bus, "_persist", lambda *a, **k: None)
+    monkeypatch.setattr(bus, "_append_jsonl", lambda *a, **k: None)
+    return bus
+
+
+def test_on_invokes_only_matching_event(monkeypatch):
+    bus = _make_bus(monkeypatch)
+    seen: list[dict] = []
+    bus.on("x.evt", lambda d: seen.append(d))
+
+    bus.emit("x.evt", {"v": 1})
+    bus.emit("other.evt", {"v": 2})
+
+    assert seen == [{"v": 1}]
+
+
+def test_on_is_idempotent(monkeypatch):
+    """Registering the same (event_type, callback) repeatedly fires once."""
+    bus = _make_bus(monkeypatch)
+    calls: list[dict] = []
+
+    def cb(d: dict) -> None:
+        calls.append(d)
+
+    bus.on("x.evt", cb)
+    bus.on("x.evt", cb)
+    bus.on("x.evt", cb)
+
+    bus.emit("x.evt", {"v": 1})
+
+    assert len(calls) == 1
+
+
+def test_wildcard_listener_receives_all(monkeypatch):
+    bus = _make_bus(monkeypatch)
+    seen: list[dict] = []
+    bus.on(None, lambda d: seen.append(d))
+
+    bus.emit("a", {"n": 1})
+    bus.emit("b", {"n": 2})
+
+    assert len(seen) == 2
+
+
+def test_listener_error_does_not_break_emit(monkeypatch):
+    bus = _make_bus(monkeypatch)
+    ok: list[dict] = []
+
+    def boom(_d: dict) -> None:
+        raise RuntimeError("listener blew up")
+
+    bus.on("e", boom)
+    bus.on("e", lambda d: ok.append(d))
+
+    # Must not raise even though the first listener throws.
+    bus.emit("e", {})
+
+    assert len(ok) == 1
+
+
+def test_off_removes_listener(monkeypatch):
+    bus = _make_bus(monkeypatch)
+    seen: list[dict] = []
+
+    def cb(d: dict) -> None:
+        seen.append(d)
+
+    bus.on("e", cb)
+    bus.off("e", cb)
+    bus.emit("e", {})
+
+    assert seen == []
+
+
+def test_reentrant_emit_in_listener_is_safe(monkeypatch):
+    """A listener that emits another event must not corrupt iteration."""
+    bus = _make_bus(monkeypatch)
+    outer: list[dict] = []
+    inner: list[dict] = []
+
+    bus.on("inner", lambda d: inner.append(d))
+    bus.on("outer", lambda d: (outer.append(d), bus.emit("inner", {"from": "outer"})))
+
+    bus.emit("outer", {"v": 1})
+
+    assert len(outer) == 1
+    assert inner == [{"from": "outer"}]
+
+
+def test_register_event_listeners_is_idempotent(monkeypatch):
+    """The real scheduler hook must not stack on repeated startup calls."""
+    monkeypatch.setattr(event_bus, "_persist", lambda *a, **k: None)
+    monkeypatch.setattr(event_bus, "_append_jsonl", lambda *a, **k: None)
+    monkeypatch.setattr(event_bus, "_listeners", [])
+
+    calls: list[dict] = []
+    monkeypatch.setattr(sched, "on_cycle_completed", lambda d: calls.append(d))
+
+    sched.register_event_listeners()
+    sched.register_event_listeners()  # second startup must not double-register
+
+    event_bus.emit("self_improve.cycle_completed", {"cycle_id": "abc"})
+
+    assert len(calls) == 1

--- a/backend/tests/test_self_improve_recovery.py
+++ b/backend/tests/test_self_improve_recovery.py
@@ -1,0 +1,154 @@
+"""Regression tests for the self-improve cycle robustness fixes.
+
+Covers three bugs found when cycle 9faac75d wedged in 'planning' for 24 days
+having spawned 0 agents, produced 0 improvements, and leaked the lock file:
+
+  Patch 1 (start_cycle): the PM-prompt build + first agent spawn ran OUTSIDE
+    the lock-guarded try/except, so any throw wedged the cycle in 'planning'
+    forever, leaked the lock, and recorded no error. Now guarded -> the cycle
+    is marked 'failed' with the error and the lock is released.
+
+  Patch 2 (_spawn_squad_agent): an explicit db.commit() between the two INSERTs
+    made the agents row and its self_improve_agents link non-atomic, allowing
+    an orphan agents row with no cycle link. Now a single get_db() transaction
+    writes both atomically.
+
+  Patch 3 (recover_interrupted_cycles): nothing previously reconciled a cycle
+    left mid-flight by a crash/restart. Now startup fails such cycles (but
+    preserves 'awaiting_approval', which legitimately waits for a human).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.services import self_improve as si
+from app.services.self_improve import SelfImproveService
+from app.db.session import get_db
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _insert_cycle(cycle_id: str, status: str = "planning", error: str = "") -> None:
+    with get_db() as db:
+        db.exec_driver_sql(
+            "INSERT INTO self_improve_cycles "
+            "(id, status, budget_usd, spent_usd, max_improvements, error, started_at, created_at) "
+            "VALUES (?, ?, 5.0, 0.0, 5, ?, ?, ?)",
+            (cycle_id, status, error, _now(), _now()),
+        )
+
+
+@pytest.fixture()
+def hermetic(monkeypatch):
+    """Neutralize host-touching side effects (lock file, git, events)."""
+    released = {"count": 0}
+    monkeypatch.setattr(si, "_acquire_lock", lambda: True)
+    monkeypatch.setattr(si, "_check_disk_space", lambda *a, **k: True)
+    monkeypatch.setattr(si, "cleanup_stale_worktrees", lambda *a, **k: None)
+
+    def _fake_release():
+        released["count"] += 1
+
+    monkeypatch.setattr(si, "_release_lock", _fake_release)
+    monkeypatch.setattr(si.event_bus, "emit", lambda *a, **k: None)
+    return released
+
+
+# ---------------------------------------------------------------------------
+# Patch 1 — start_cycle no longer wedges on spawn failure
+# ---------------------------------------------------------------------------
+
+def test_start_cycle_spawn_failure_fails_cycle_and_releases_lock(fresh_db, hermetic, monkeypatch):
+    monkeypatch.setattr(
+        si.process_manager, "spawn",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("claude not found")),
+    )
+    svc = SelfImproveService()
+
+    with pytest.raises(RuntimeError):
+        svc.start_cycle(budget_usd=5.0, max_improvements=3, focus_areas=None)
+
+    # Cycle must be 'failed' with the error recorded -- NOT stuck in 'planning'.
+    with get_db() as db:
+        rows = db.exec_driver_sql(
+            "SELECT status, error, completed_at FROM self_improve_cycles"
+        ).fetchall()
+    assert len(rows) == 1
+    row = rows[0]._mapping
+    assert row["status"] == "failed"
+    assert "Failed to spawn PM agent" in (row["error"] or "")
+    assert row["completed_at"]
+
+    # Lock released and in-memory active state cleared (recoverable).
+    assert hermetic["count"] >= 1
+    assert svc._active_cycle_id is None
+
+
+# ---------------------------------------------------------------------------
+# Patch 2 — agents + self_improve_agents written atomically
+# ---------------------------------------------------------------------------
+
+def test_spawn_squad_agent_writes_both_rows_atomically(fresh_db, hermetic, monkeypatch):
+    monkeypatch.setattr(si.process_manager, "spawn", lambda *a, **k: 4321)
+    svc = SelfImproveService()
+    _insert_cycle("cyc-1", status="planning")
+
+    agent_id = svc._spawn_squad_agent("cyc-1", "pm", "do the thing")
+
+    with get_db() as db:
+        a = db.exec_driver_sql(
+            "SELECT pid, role FROM agents WHERE id = ?", (agent_id,)
+        ).fetchone()
+        link = db.exec_driver_sql(
+            "SELECT COUNT(*) AS n FROM self_improve_agents WHERE cycle_id = ? AND agent_id = ?",
+            ("cyc-1", agent_id),
+        ).fetchone()
+
+    assert a is not None and a._mapping["role"] == "self-improve-pm"
+    assert a._mapping["pid"] == 4321
+    # The link row exists -> both inserts committed together (no orphan).
+    assert link._mapping["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Patch 3 — crash recovery fails interrupted cycles, spares awaiting_approval
+# ---------------------------------------------------------------------------
+
+def test_recover_interrupted_cycles(fresh_db, hermetic):
+    _insert_cycle("c-planning", status="planning")
+    _insert_cycle("c-developing", status="developing")
+    _insert_cycle("c-await", status="awaiting_approval")
+    _insert_cycle("c-done", status="completed")
+
+    svc = SelfImproveService()
+    recovered = svc.recover_interrupted_cycles()
+
+    assert recovered == 2  # only the two processing states
+    with get_db() as db:
+        statuses = {
+            r._mapping["id"]: (r._mapping["status"], r._mapping["error"])
+            for r in db.exec_driver_sql(
+                "SELECT id, status, error FROM self_improve_cycles"
+            ).fetchall()
+        }
+
+    assert statuses["c-planning"][0] == "failed"
+    assert "Interrupted by restart" in (statuses["c-planning"][1] or "")
+    assert statuses["c-developing"][0] == "failed"
+    # Human gate + terminal states are preserved.
+    assert statuses["c-await"][0] == "awaiting_approval"
+    assert statuses["c-done"][0] == "completed"
+    # Lock released because cycles were recovered.
+    assert hermetic["count"] >= 1
+
+
+def test_recover_interrupted_cycles_noop_when_clean(fresh_db, hermetic):
+    _insert_cycle("c-await", status="awaiting_approval")
+    _insert_cycle("c-done", status="completed")
+    svc = SelfImproveService()
+    assert svc.recover_interrupted_cycles() == 0

--- a/backend/tests/test_wave01_persistence.py
+++ b/backend/tests/test_wave01_persistence.py
@@ -1,0 +1,168 @@
+"""Wave 0.1 write-path regression tests (Track 0 foundation remediation).
+
+These assert that rows ACTUALLY LAND — the class of bug the audit found across
+the write plane (success-shaped responses that persist nothing because an
+exception was swallowed or a column/CHECK mismatched).
+
+Covers:
+  #1  cost_ledger source vocabulary (widened CHECK accepts the real writers)
+  #2  auto_classifier persistence (upsert kwargs) + content classify idempotency
+  #3  content-to-action staging + approve (staged_actions column alignment)
+  #11 chat SDK path records cost once, not twice
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+
+from app.db.session import get_db
+
+
+def _count(table: str, where: str = "", params: tuple = ()) -> int:
+    with get_db() as db:
+        return db.exec_driver_sql(
+            f"SELECT COUNT(*) AS c FROM {table} {where}", params
+        ).fetchone()._mapping["c"]
+
+
+def _seed_hub_content(cid: str, body: str, title: str = "Note") -> None:
+    with get_db() as db:
+        db.exec_driver_sql(
+            "INSERT INTO hub_content (id, title, raw_text) VALUES (?, ?, ?)",
+            (cid, title, body),
+        )
+
+
+# ---------------------------------------------------------------------------
+# #2 — auto_classifier persistence
+# ---------------------------------------------------------------------------
+
+def test_apply_classification_persists_row(fresh_db):
+    from app.services import auto_classifier as ac
+    ac._apply_classification("hub-1", "proj-1", 0.91, "looks like proj-1", auto=True)
+    assert _count("content_classifications", "WHERE hub_content_id = ?", ("hub-1",)) == 1
+
+
+def test_save_suggestion_persists_row(fresh_db):
+    from app.services import auto_classifier as ac
+    ac._save_suggestion("hub-2", "proj-2", 0.66, "maybe proj-2")
+    assert _count("content_classifications", "WHERE hub_content_id = ?", ("hub-2",)) == 1
+
+
+def test_apply_classification_is_idempotent_on_hub_content_id(fresh_db):
+    from app.services import auto_classifier as ac
+    ac._apply_classification("hub-3", "proj-a", 0.5, "first", auto=True)
+    ac._apply_classification("hub-3", "proj-b", 0.9, "second", auto=True)
+    # upsert on hub_content_id -> still one row, updated in place
+    assert _count("content_classifications", "WHERE hub_content_id = ?", ("hub-3",)) == 1
+    with get_db() as db:
+        row = db.exec_driver_sql(
+            "SELECT classified_project_id FROM content_classifications WHERE hub_content_id = ?",
+            ("hub-3",),
+        ).fetchone()
+    assert row._mapping["classified_project_id"] == "proj-b"
+
+
+# ---------------------------------------------------------------------------
+# #2b — content router classify/dismiss idempotency (conflict target fix)
+# ---------------------------------------------------------------------------
+
+def test_classify_content_endpoint_idempotent(fresh_db):
+    from app.routers.content import classify_content, ClassifyContentBody
+    _seed_hub_content("c-1", "TODO: nothing here")
+    classify_content("c-1", ClassifyContentBody(project_id="p1"))
+    # Second classify of the SAME content must update in place, not 500.
+    classify_content("c-1", ClassifyContentBody(project_id="p2"))
+    assert _count("content_classifications", "WHERE hub_content_id = ?", ("c-1",)) == 1
+
+
+# ---------------------------------------------------------------------------
+# #3 — content-to-action staging + approve
+# ---------------------------------------------------------------------------
+
+def test_process_content_stages_action(fresh_db):
+    from app.services import action_pipeline as ap
+    _seed_hub_content("c-2", "Meeting recap.\nTODO: send the contract to Aude\nThanks")
+    staged = ap.process_content("c-2", mode="regex")
+    assert len(staged) >= 1
+    assert _count("staged_actions", "WHERE content_id = ?", ("c-2",)) >= 1
+
+
+def test_approve_action_creates_todo(fresh_db):
+    from app.services import action_pipeline as ap
+    _seed_hub_content("c-3", "TODO: file the report")
+    staged = ap.process_content("c-3", mode="regex")
+    action_id = staged[0]["id"]
+    result = ap.approve_action(action_id)
+    assert result is not None and result["status"] == "approved"
+    assert result.get("created_todo_id")
+    with get_db() as db:
+        row = db.exec_driver_sql(
+            "SELECT status, created_todo_id FROM staged_actions WHERE id = ?",
+            (action_id,),
+        ).fetchone()
+    assert row._mapping["status"] == "approved"
+    assert row._mapping["created_todo_id"]
+
+
+# ---------------------------------------------------------------------------
+# #1 — cost_ledger source vocabulary (widened CHECK)
+# ---------------------------------------------------------------------------
+
+REAL_SOURCES = ["station", "chat", "think", "kh_pipeline", "agent", "classifier", "brain", "api_token"]
+
+
+@pytest.mark.parametrize("source", REAL_SOURCES)
+def test_cost_ledger_accepts_real_sources(fresh_db, source):
+    from app.services.agent_sdk_client import record_sdk_cost
+    record_sdk_cost(model="claude-haiku-4-5-20251001", input_tokens=10, output_tokens=5, source=source)
+    assert _count("cost_ledger", "WHERE source = ?", (source,)) == 1
+
+
+def test_cost_ledger_rejects_unknown_source(fresh_db):
+    """The widened CHECK still rejects garbage (proves it is enforced, not absent)."""
+    import sqlalchemy
+    from app.db.tables import cost_ledger
+    with pytest.raises((sqlalchemy.exc.IntegrityError, sqlalchemy.exc.OperationalError)):
+        with get_db() as db:
+            db.execute(
+                cost_ledger.insert().values(
+                    id=uuid.uuid4().hex, model="m", input_tokens=1, output_tokens=1,
+                    cost_usd=0.0, source="totally-bogus-source", created_at="2026-06-01",
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# #11 — chat SDK path records cost exactly once
+# ---------------------------------------------------------------------------
+
+def test_sdk_chat_generator_does_not_record_cost_itself(fresh_db, monkeypatch):
+    """stream_chat already records via _record_dual; the generator must NOT
+    record again (that was the 2x cost-inflation bug)."""
+    import app.routers.chat as chat
+    from app.services import agent_sdk_client as sdk
+
+    calls = {"n": 0}
+    monkeypatch.setattr(sdk, "record_sdk_cost", lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
+    # Isolate from persistence side-effects.
+    monkeypatch.setattr(chat, "_save_message", lambda *a, **k: None)
+    monkeypatch.setattr(chat, "_update_session_after_message", lambda *a, **k: None)
+
+    async def fake_stream(*a, **k):
+        yield {"type": "token", "content": "hi"}
+        yield {"type": "usage", "input_tokens": 12, "output_tokens": 7, "model": "claude-sonnet-4-6"}
+        yield {"type": "done", "content": "hi"}
+
+    monkeypatch.setattr(sdk.agent_sdk, "stream_chat", fake_stream)
+
+    async def drive():
+        async for _ in chat._sdk_chat_event_generator("hello", "sonnet", "sys", session_id=None):
+            pass
+
+    asyncio.run(drive())
+    # The generator must not call record_sdk_cost; stream_chat owns recording.
+    assert calls["n"] == 0


### PR DESCRIPTION
## Track 0 Wave 0.1 — Cost / Classification Write-Plane Fixes

Foundation remediation from the feature-reality audit, which found the write/persistence plane silently dropping rows (swallowed exceptions + 3-way schema drift between `tables.py`, `models.py`, and the live legacy DDL). This is the smallest high-leverage slice: the cost/classification spine.

### What changed

**Cost recording (#1)** — the live `cost_ledger.source` CHECK only allowed `station/chat/think/kh_pipeline`, but the app writes `agent`/`classifier`/`brain`; the `IntegrityError` was swallowed, so the ledger stayed at 0 rows.
- Widened the CHECK in `tables.py` (canonical) + added `created_at` server_default.
- Alembic migration `009` rebuilds the live table with the widened CHECK (SQLite recreate-table pattern).
- `record_sdk_cost` failure now logs at ERROR (was a silent warning).

**Classifier persistence (#2 / #2b)**
- `auto_classifier` passed `conflict_cols`/`update_cols` (wrong) to `upsert()` → swallowed `TypeError` → 0 rows. Fixed to `conflict_columns`/`update_columns`.
- `content_classifications.hub_content_id` made `UNIQUE` in `tables.py` (parity with live; required for the `ON CONFLICT` to work on fresh DBs).
- `content.py` classify/dismiss conflict target `['id']` → `['hub_content_id']`.

**Content-to-Action (#3)**
- `action_pipeline` wrote phantom `staged_actions` columns (`extraction_mode`, `updated_at`, `result_id`) → `CompileError` on every call. Removed; `approve` now sets `created_todo_id`.
- Latent bug also fixed: `process_content` read `.get("body")` but `row._mapping` is keyed `raw_text`/`processed_text` → extraction always returned empty. Now reads either.

**Chat (#11)**
- SDK path double-recorded cost (`stream_chat._record_dual` then the generator again). Removed the redundant generator-side record; `stream_chat` owns it.

### Evidence (`.team-ship/EVIDENCE.md`)

- **TDD red→green:** `tests/test_wave01_persistence.py` (16 tests) — 16 failed before fixes, 16 passed after.
- **Full suite:** `378 passed, 9 skipped` (`uv run pytest`). The 9 skips are pre-existing integration tests gated on unprovisioned deps — flagged UNVERIFIED, not "passed".
- **Live migration:** applied to `~/.coco/platform.db` (backup taken); CHECK verified widened, `source='agent'` accepted, bogus rejected.
- **Independent re-run:** 27 tests re-passed in a fresh process.

### Honest gaps

- **Lint:** the CI gate `uv run ruff check .` could not run (ruff not in the synced venv). Mirrored via `uvx ruff@latest` on the changed files: **my diff is lint-clean** — all reported `B904`/`RUF010` are at pre-existing lines outside this diff. Full-repo lint was not run here; pre-existing repo lint debt is out of scope.
- This is Wave 0.1 only. Waves 0.2–0.5 (schema reconcile, persistence gaps, Brain v3 corpus, dead-code) remain — see the master plan.

Two commits: `0.0` (self_improve lifecycle + event_bus listener API, also foundation, fixed earlier this session) and `0.1` (this scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
