### PR TITLE
0.2: reconcile insights/verification/tasks schema drift (Track 0 Wave 0.2)

### DIFF
--- a/.team-ship/EVIDENCE.md
+++ b/.team-ship/EVIDENCE.md
@@ -71,3 +71,27 @@ Backup taken before migration: `~/.coco/platform.db.pre009.<ts>`.
 
 1. `content_classifications.hub_content_id` lacked `UNIQUE` in `tables.py` → `ON CONFLICT` failed on fresh DBs (live had it). Fixed (parity).
 2. `process_content` read `.get("body")` but `row._mapping` is keyed `raw_text`/`processed_text` → extraction always empty → zero actions, ever. Fixed.
+
+---
+
+# Wave 0.2 — Schema Reconcile (#4 insights, #5 verification, #10 tasks)
+
+## Tests
+```
+$ uv run pytest tests/test_wave02_schema.py -q
+8 passed
+$ uv run pytest -q          # full suite
+386 passed, 9 skipped
+```
+- #4 is red→green (insights insert with metadata_json/updated_at: CompileError before tables.py gained the columns).
+- #5 and #10 are live-migration fixes (fresh create_all DBs already match tables.py); tests guard the canonical schema + the get_history JOIN.
+
+## Live migration 010 (applied, backup `platform.db.pre010.<ts>`)
+```
+$ uv run alembic upgrade head   # 009 -> 010
+$ PRAGMA table_info(insights) | grep         -> metadata_json, updated_at   (#4)
+$ .schema verification_results | grep        -> gate TEXT NOT NULL          (#5, was gate_name/passed/score)
+$ .schema tasks | grep status                -> status TEXT NOT NULL DEFAULT 'open'   (no CHECK)  (#10)
+$ INSERT tasks ... status='backlog'          -> backlog OK                 (#10, old CHECK rejected it)
+$ SELECT status,COUNT(*) FROM tasks          -> done|17 (rows preserved)
+```

--- a/backend/alembic/versions/010_wave02_schema_reconcile.py
+++ b/backend/alembic/versions/010_wave02_schema_reconcile.py
@@ -1,0 +1,124 @@
+"""Wave 0.2 schema reconcile: insights, verification_results, tasks.
+
+Revision ID: 010_wave02_schema_reconcile
+Revises: 009_widen_cost_ledger_source
+Create Date: 2026-06-01
+
+Reconciles three tables on existing platform.db installs to match db/tables.py
+(the create_all source of truth), fixing silent write failures:
+
+  #4 insights            -- add metadata_json + updated_at columns the engine
+                            writes (CompileError / NOT NULL on every cycle).
+  #5 verification_results -- live table used the legacy models.py schema
+                            (gate_name/passed/score); rebuild to the new schema
+                            (gate/verdict/checks_json/...) the service inserts.
+                            Live table has 0 rows, so no data is lost.
+  #10 tasks              -- drop the stale status CHECK that rejected the board
+                            states the router emits (backlog/todo/in_review/
+                            archived); the app's TASK_STATES governs instead.
+
+All steps are idempotent and committed explicitly (SQLite non-transactional DDL).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "010_wave02_schema_reconcile"
+down_revision: Union[str, None] = "009_widen_cost_ledger_source"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_column(bind, table: str, column: str) -> bool:
+    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+_VR_NEW = """
+    CREATE TABLE verification_results (
+        id TEXT PRIMARY KEY,
+        gate TEXT NOT NULL,
+        verdict TEXT NOT NULL,
+        checks_json TEXT,
+        summary TEXT,
+        node_id TEXT,
+        entity_type TEXT,
+        entity_id TEXT,
+        retry_count INTEGER DEFAULT 0,
+        budget_spent_usd REAL DEFAULT 0.0,
+        run_at TEXT NOT NULL,
+        duration_ms INTEGER DEFAULT 0
+    );
+"""
+
+_TASKS_COLS = (
+    "id, title, description, agent_id, project_id, status, priority, "
+    "checked_out_by, checked_out_at, created_at, updated_at, node_id, "
+    "delegated_by, delegated_to, parent_task_id, context_json"
+)
+
+_TASKS_NEW = """
+    CREATE TABLE tasks_new (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        description TEXT,
+        agent_id TEXT REFERENCES "agents"(id),
+        project_id TEXT,
+        status TEXT NOT NULL DEFAULT 'open',
+        priority TEXT DEFAULT 'medium' CHECK(priority IN ('high','medium','low')),
+        checked_out_by TEXT,
+        checked_out_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        node_id TEXT,
+        delegated_by TEXT,
+        delegated_to TEXT,
+        parent_task_id TEXT,
+        context_json TEXT DEFAULT '{}'
+    );
+"""
+
+_TASKS_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_tasks_project ON tasks(project_id)",
+    "CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status)",
+    "CREATE INDEX IF NOT EXISTS idx_tasks_node ON tasks(node_id)",
+    "CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_task_id)",
+    "CREATE INDEX IF NOT EXISTS idx_tasks_delegated_to ON tasks(delegated_to)",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # #4 insights: add the columns the engine writes.
+    if not _has_column(bind, "insights", "metadata_json"):
+        bind.exec_driver_sql("ALTER TABLE insights ADD COLUMN metadata_json TEXT DEFAULT '{}'")
+    if not _has_column(bind, "insights", "updated_at"):
+        bind.exec_driver_sql("ALTER TABLE insights ADD COLUMN updated_at TEXT")
+
+    # #5 verification_results: rebuild legacy schema -> new schema (0 rows live).
+    bind.exec_driver_sql("DROP TABLE IF EXISTS verification_results")
+    bind.exec_driver_sql(_VR_NEW)
+    bind.exec_driver_sql("CREATE INDEX IF NOT EXISTS idx_vr_gate ON verification_results(gate)")
+    bind.exec_driver_sql(
+        "CREATE INDEX IF NOT EXISTS idx_vr_entity ON verification_results(entity_type, entity_id)"
+    )
+
+    # #10 tasks: drop the stale status CHECK (recreate-table), preserve rows.
+    bind.exec_driver_sql("DROP TABLE IF EXISTS tasks_new")
+    bind.exec_driver_sql(_TASKS_NEW)
+    bind.exec_driver_sql(
+        f"INSERT INTO tasks_new ({_TASKS_COLS}) SELECT {_TASKS_COLS} FROM tasks"
+    )
+    bind.exec_driver_sql("DROP TABLE tasks")
+    bind.exec_driver_sql("ALTER TABLE tasks_new RENAME TO tasks")
+    for stmt in _TASKS_INDEXES:
+        bind.exec_driver_sql(stmt)
+
+    bind.commit()
+
+
+def downgrade() -> None:
+    # Non-reversible in practice (would reinstate broken CHECK / drop columns).
+    # Left as a no-op to avoid re-breaking the write plane.
+    pass

--- a/backend/app/db/tables.py
+++ b/backend/app/db/tables.py
@@ -903,7 +903,9 @@ insights = Table(
     Column("content_ids", Text, default="[]"),
     Column("sources", Text, default="[]"),
     Column("status", Text, default="new"),
+    Column("metadata_json", Text, server_default="{}"),
     Column("created_at", Text),
+    Column("updated_at", Text),
 )
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/insight_engine.py
+++ b/backend/app/services/insight_engine.py
@@ -370,6 +370,7 @@ def generate_insights(limit: int = 50) -> list[dict]:
                     status="new",
                     entity_ids=json.dumps(ins["entity_ids"]),
                     content_ids=json.dumps(ins["content_ids"]),
+                    sources=json.dumps(ins.get("sources", [])),
                     metadata_json=ins.get("metadata_json", "{}"),
                     created_at=now,
                     updated_at=now,

--- a/backend/app/services/verification.py
+++ b/backend/app/services/verification.py
@@ -444,7 +444,9 @@ class VerificationService:
                     )
                 )
         except Exception as e:
-            log.warning("verification_gate_persist_failed", error=str(e))
+            # Loud, not swallowed: a schema mismatch here silently kept
+            # verification_results empty despite gates running.
+            log.error("verification_gate_persist_failed", error=str(e))
 
     def get_history(self, entity_type: str | None = None, entity_id: str | None = None,
                     node_id: str | None = None, limit: int = 20) -> list[dict]:

--- a/backend/tests/test_wave02_schema.py
+++ b/backend/tests/test_wave02_schema.py
@@ -1,0 +1,69 @@
+"""Wave 0.2 schema-reconcile regression tests (Track 0).
+
+  #4  insights  -- table accepts metadata_json/updated_at/sources the engine writes
+  #5  verification_results -- new schema (gate/verdict/checks_json) + get_history JOIN runs
+  #10 tasks     -- accepts the board states the router emits (no stale status CHECK)
+
+#5 and #10 are live-migration fixes (fresh create_all DBs already match tables.py);
+these tests guard the canonical schema + the JOIN, and migration 010 reconciles
+the live DB (verified separately).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db.session import get_db
+
+
+def _count(table: str, where: str = "", params: tuple = ()) -> int:
+    with get_db() as db:
+        return db.exec_driver_sql(
+            f"SELECT COUNT(*) AS c FROM {table} {where}", params
+        ).fetchone()._mapping["c"]
+
+
+# #4 — insights accepts the engine's columns (RED before tables.py gained
+# metadata_json/updated_at: CompileError on unknown columns).
+def test_insights_table_accepts_engine_columns(fresh_db):
+    from app.db.tables import insights
+    with get_db() as db:
+        db.execute(
+            insights.insert().values(
+                id="i1", insight_type="cross_ref", title="t", description="d",
+                confidence=0.7, entity_ids="[]", content_ids="[]", sources="[]",
+                status="new", metadata_json='{"k":1}',
+                created_at="2026-06-01", updated_at="2026-06-01",
+            )
+        )
+    assert _count("insights", "WHERE id = ?", ("i1",)) == 1
+
+
+# #5 — verification_results new schema + get_history JOIN on vr.gate runs clean.
+def test_verification_results_new_schema_and_history(fresh_db):
+    from app.db.tables import verification_results
+    from app.services.verification import verification_service
+    with get_db() as db:
+        db.execute(
+            verification_results.insert().values(
+                id="v1", gate="ideation", verdict="pass", checks_json="[]",
+                summary="ok", run_at="2026-06-01",
+            )
+        )
+    assert _count("verification_results", "WHERE gate = ?", ("ideation",)) == 1
+    hist = verification_service.get_history()  # JOINs on vr.gate — must not raise
+    assert isinstance(hist, list)
+
+
+# #10 — tasks accepts every router board state (no blocking status CHECK).
+@pytest.mark.parametrize("state", ["backlog", "todo", "in_progress", "in_review", "done", "archived"])
+def test_tasks_accepts_board_states(fresh_db, state):
+    from app.db.tables import tasks
+    with get_db() as db:
+        db.execute(
+            tasks.insert().values(
+                id=f"t-{state}", title="x", status=state,
+                created_at="2026-06-01", updated_at="2026-06-01",
+            )
+        )
+    assert _count("tasks", "WHERE status = ?", (state,)) == 1


### PR DESCRIPTION
Stacked on #19. Fixes 3 schema-drift bugs from the audit (write plane silently dropped rows).

- **#4 insights** — added `metadata_json`+`updated_at` (tables.py + migration 010 ADD COLUMN); engine now sets `sources` (live NOT NULL). Was: CompileError every cycle, 0 rows.
- **#5 verification_results** — rebuilt live legacy schema (`gate_name/passed/score`) → new tables.py schema (`gate/verdict/checks_json`); `get_history` JOIN now resolves; persist failure logs ERROR (was swallowed). Live had 0 rows.
- **#10 tasks** — dropped the stale `status` CHECK that rejected router board states (`backlog/todo/in_review/archived`); app `TASK_STATES` governs. 17 existing rows preserved.

### Evidence
- `test_wave02_schema.py` (8) + full suite **386 passed, 9 skipped**.
- Migration **010** applied to live (backup taken) and verified: insights cols present; verification_results new schema; tasks accepts `backlog`; rows preserved.
- #4 red→green; #5/#10 are live-migration fixes (fresh DBs already matched tables.py) — tests guard canonical schema + JOIN.

Deferred to next: #13 schema-hardening (fresh-DB parity, no live failure) folds into Wave 0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)