### PR TITLE
docs(readme): rewrite README to show true scale of 860 assets and 389-persona Superintelligence board

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,29 @@
 
 <img src="assets/logo-light.svg" alt="Coco" width="160" height="220">
 
-# Coco is now superintelligent.
+# Coco: The Universal AI Agent Orchestration Framework
 
-### <sub>A board of the world's top minds — Karpathy, Hinton, +180 more — wherever your AI lives.</sub><br>Free. MIT. 90 seconds.
+### Transform your AI coding assistant into a high-performance engineering team, backed by an advisory board of 389 world-class minds.
+Free | MIT License | 90-Second Onboarding
 
 <br>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/license/mit)
 [![Version](https://img.shields.io/badge/version-0.1.0-blue?style=for-the-badge)](CHANGELOG.md)
-[![Skills](https://img.shields.io/badge/skills-59-green?style=for-the-badge)](skills/)
+[![Skills](https://img.shields.io/badge/skills-142-emerald?style=for-the-badge)](skills/)
+[![Commands](https://img.shields.io/badge/commands-277-indigo?style=for-the-badge)](commands/)
+[![Personas](https://img.shields.io/badge/personas-389-violet?style=for-the-badge)](systems/superintelligence/)
 [![CI](https://img.shields.io/github/actions/workflow/status/rkz91/coco/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/rkz91/coco/actions)
-[![GitHub stars](https://img.shields.io/github/stars/rkz91/coco?style=for-the-badge&logo=github)](https://github.com/rkz91/coco)
 
 <br>
 
 <p>
 &nbsp;&nbsp;<a href="#install"><kbd> &nbsp; Install &nbsp; </kbd></a>&nbsp;&nbsp;
-<a href="#three-pillars"><kbd> &nbsp; What it does &nbsp; </kbd></a>&nbsp;&nbsp;
-<a href="#see-it-run"><kbd> &nbsp; Demos &nbsp; </kbd></a>&nbsp;&nbsp;
-<a href="#built-on"><kbd> &nbsp; Built on &nbsp; </kbd></a>&nbsp;&nbsp;
-<a href="docs/architecture.md"><kbd> &nbsp; Architecture &nbsp; </kbd></a>
+<a href="#core-feature-coco-superintelligence"><kbd> &nbsp; Superintelligence &nbsp; </kbd></a>&nbsp;&nbsp;
+<a href="#three-pillars"><kbd> &nbsp; Core Architecture &nbsp; </kbd></a>&nbsp;&nbsp;
+<a href="#skills-catalog-deep-dive"><kbd> &nbsp; Skills &nbsp; </kbd></a>&nbsp;&nbsp;
+<a href="#system-bundles-deep-dive"><kbd> &nbsp; Systems &nbsp; </kbd></a>&nbsp;&nbsp;
+<a href="#see-it-run"><kbd> &nbsp; Demos &nbsp; </kbd></a>
 </p>
 
 <br>
@@ -34,10 +37,9 @@
 
 <div align="center">
 
-> **One coder typing prompts? That was last year.**
+> **One developer writing single prompts? That was last year.**
 >
-> Coco turns your AI tool into a team. Multiple agents. Working in parallel.<br>
-> State that survives. Verification before "done." Free. MIT. Yours.
+> Coco turns your AI coding session into an entire engineering department. It spawns specialized agents, runs parallel code tasks, coordinates complex review panels, persists phase state across resets, and enforces deterministic verification gates before code is committed.
 
 </div>
 
@@ -45,65 +47,94 @@
 git clone https://github.com/rkz91/coco.git && cd coco && bash install.sh
 ```
 
-<div align="center"><sub>90 seconds. That's the whole onboarding.</sub></div>
+<div align="center"><sub>90 seconds. That's all it takes to wire Coco's workspace engine into your IDE.</sub></div>
 
 ---
 
-## What you get
+## Core Feature: Coco Superintelligence
 
-<div align="center">
+### A Cross-Team Advisory Board of 389 World-Class Minds
 
-<sub>USER-INVOKABLE</sub>
+Coco's signature differentiator is Superintelligence. It allows you to summon custom, real-world expert panels directly inside your coding sessions to guide architectural, engineering, risk, finance, and business decisions:
 
-<h1>94</h1>
+```bash
+/SI-Decide "Should we migrate our database to pgvector?"
+/SI-AI-Decide "Which embedding model gives the best cost/performance?"
+/SI-Eng-Pre-Mortem "Review our zero-downtime cache migration strategy"
+/SI-GRC-Review "Check this customer onboarding flow for GDPR compliance"
+```
 
-<sub>things you can invoke right after install</sub>
+*   **389 Expert Personas**: Organized across 9 specialized departments:
+    *   **Engineering** (70 experts): Experts in software architecture, cloud systems, systems coding, compilers, and infrastructure.
+    *   **AI** (59 experts): Neural network research, LLM optimization, safety, alignment, and vector database engineering.
+    *   **Product and Design** (56 experts): Design systems, UX design, product strategy, and growth loops.
+    *   **Finance** (47 experts): Valuation, corporate finance, macroeconomic modeling, and fintech infrastructure.
+    *   **Trading** (46 experts): Quantitative analysis, market microstructure, derivatives pricing, and crypto liquidity.
+    *   **Risk and Compliance / GRC** (30 experts): GDPR, HIPAA, SOC2 compliance, security auditing, and international regulations.
+    *   **Strategy** (29 experts): Platform economics, business models, competitive analysis, and strategic growth.
+    *   **Data and Analytics** (29 experts): Data engineering, pipeline optimization, predictive modeling, and analytics stacks.
+    *   **Sales / GTM / Marketing** (23 experts): Product-market fit, sales operations, growth marketing, and enterprise GTM.
+*   **242 Generated Slash Commands**: Comprises 17 Cross-Team Meta Commands (like `/SI-Decide` or `/SI-Tradeoff` routing across multiple domains) and 225 Per-Team Commands (25 per team, such as `/SI-AI-Decide` or `/SI-Eng-Pre-Mortem`).
+*   **Cross-Team Meta-Orchestration**: For complex queries spanning domains ("build and sell an AI audit tool"), a Stage-A local router uses nomic-embed to score the prompt against team registries and cells, greedily picking a proportional 16-32 person panel.
+*   **Citable and Grounded**: Every stance is verified from public sources and carries a direct evidence URL. Personas are validated against a strict anti-fabrication gate.
 
-</div>
+### The Two-Stage Selection Algorithm
+
+The Meta-Orchestrator uses a highly optimized two-stage algorithm to avoid loading massive file systems at runtime:
+
+1.  **Stage A: Team and Cell Routing (Cheap)**: Reads the meta-registry (`superintelligence/registry.json`) and scans only the team descriptions and cell definitions. It scores team relevance using keyword and domain overlap, selecting the top 1-4 teams. If a single team dominates, it delegates to that team's normal orchestrator.
+2.  **Stage B: Scoped Persona Selection (Scoped)**: Loads compact persona records (slugs, cells, domains, stances, conflict mappings) for only the selected teams. It allocates the 16-32 panel budget proportionally to team relevance, runs the greedy scorer (`0.40·domain + 0.30·cell-coverage + 0.30·conflict-pairing`), and applies a cross-team tension pass to pair opposing viewpoints (e.g., security vs. growth).
+3.  **Stage C: Approval and Execution**: Presents the roster grouped by team with a one-line selection rationale. The executing action verb consumes the approved roster, and the resulting output includes full line-by-line attribution (e.g., "Aswath Damodaran (Finance): ...").
+
+### Persona Build and Validation Pipeline
+
+The 389-persona roster was compiled using a systematic multi-tier workflow:
+- **Generation**: Evaluated Local Qwen 3.6 (via LM Studio) -> GPT-5-Nano (via QB Gateway) -> Gemini 3.5 Flash -> Claude Research Agents (web search). Claude research agents proved to be the quality winner for resolving historical data and cited Signal.
+- **Validation Gate**: Run via `validate_persona.py`, enforcing that every persona must have at least 4 live, non-404 cited evidence URLs, a valid home team, no fabricated quotes, and at least 2 verified signals within the last 12 months (or archetype persistent signals for historical figures).
+
+---
+
+## The Coco Asset Library
+
+A standard installation equips your workspace with a lightweight set of tools, while full activation unlocks up to 860 total assets to orchestrate any software engineering workflow:
 
 <table align="center">
 <tr>
-<td align="center" width="14%"><h3>59</h3><sub>Skills</sub></td>
-<td align="center" width="14%"><h3>35</h3><sub>Commands</sub></td>
-<td align="center" width="14%"><h3>10</h3><sub>Agents</sub><br><sub><sub>(spawned)</sub></sub></td>
-<td align="center" width="14%"><h3>4</h3><sub>Systems</sub></td>
-<td align="center" width="14%"><h3>4</h3><sub>Adapters</sub></td>
-<td align="center" width="14%"><h3>15</h3><sub>Rules</sub></td>
-<td align="center" width="16%"><h3>$0</h3><sub>Forever</sub></td>
+<td align="center" width="20%"><h3>142</h3><sub>Skills</sub><br><small>59 Core + 83 Bundle</small></td>
+<td align="center" width="20%"><h3>277</h3><sub>Slash Commands</sub><br><small>35 Core + 242 Bundle</small></td>
+<td align="center" width="20%"><h3>34</h3><sub>Specialized Agents</sub><br><small>10 Core + 24 Bundle</small></td>
+<td align="center" width="20%"><h3>389</h3><sub>Expert Personas</sub><br><small>Superintelligence Board</small></td>
+<td align="center" width="20%"><h3>15</h3><sub>Cross-IDE Rules</sub><br><small>Cursor MDC Rules</small></td>
 </tr>
 </table>
 
 <div align="center">
-
-<sub>Plus opt-in bundles: <strong>+68 GSD skills</strong> · <strong>+24 GSD agents</strong> · <strong>+6 Brain skills</strong> · Team multi-agent pipelines · <strong>+185 Superintelligence personas</strong> (3 teams, 75 commands)</sub>
-
+  <sub><strong>Core Installation:</strong> 119 active assets (59 Skills, 35 Commands, 10 Agents, 15 Rules)</sub><br>
+  <sub><strong>Orchestration Bundles:</strong> <strong>+68 GSD skills</strong> · <strong>+24 GSD agents</strong> · <strong>+6 Brain skills</strong> · <strong>+9 Superintelligence skills</strong> · <strong>+242 SI commands</strong> · <strong>3 Workflows</strong></sub>
 </div>
 
 ---
 
-## Three pillars
+## Three Pillars of Coco
 
 <table>
 <tr>
 <td width="33%" valign="top">
 
-### A team. <br>Not a single coder.
-
-`/team:ship` runs **6 build stages + 7 hard verification gates** with role-appropriate agents. Research → Architect → Plan → Review → Build — then every test/lint/coverage claim must clear an evidence gate (skip ≠ pass, independent re-run) before a PR opens. You approve once; the team can't report fake green.
-
-</td>
-<td width="33%" valign="top">
-
-### State that <br>survives anything.
-
-Most AI sessions die on `/clear`. Coco doesn't. **68 orchestration skills** with disk-backed phase state. Atomic commits per step. Roll back any decision. Resume from any checkpoint.
+### 1. Autonomous Team Execution
+`/team:ship` initiates a fully coordinated build pipeline consisting of 6 development stages and 7 hard verification gates. Specialized agents act in their specific domains (Research, Architecture, Plan, Review, Build, QA). Crucially, code changes must clear the Test Evidence Protocol (independent re-runs, strict coverage metrics, and skip-prevention) before opening a pull request.
 
 </td>
 <td width="33%" valign="top">
 
-### One install. <br>Any AI tool.
+### 2. Disk-Persistent State
+AI chat contexts are fragile and wipe on `/clear`. Coco solves this with 68 disk-backed orchestration skills that persist phase state, decisions, and progress logs across resets. Includes atomic git commits for every successful step, allowing you to review history, roll back bad design paths, or resume long-running migrations from any checkpoint.
 
-Pure markdown + frontmatter. Adapters wire into Claude Code, Cursor, Codex, or any [AGENTS.md](https://agents.md/) tool. **Switch tools in 6 months — your skills follow.**
+</td>
+<td width="33%" valign="top">
+
+### 3. Vendor-Neutral Portability
+Coco compiles its rules, templates, and agent definitions into pure Markdown and YAML frontmatter. Using native IDE adapters, the same skill library is injected into Claude Code, Cursor, Codex CLI, or any AGENTS.md compatible environment. Keep your workflows, scripts, and commands even if you switch your AI editor in the future.
 
 </td>
 </tr>
@@ -111,7 +142,69 @@ Pure markdown + frontmatter. Adapters wire into Claude Code, Cursor, Codex, or a
 
 ---
 
-## YOLO mode
+## Skills Catalog Deep-Dive
+
+Coco comes loaded with 142 skills. These are not basic prompt templates, but fully realized agent instructions containing state management, verification logic, and error handlers:
+
+### Visual Design and Styling Systems
+*   **ui-ux-pro-max**: Generates modern visual presets containing 50+ styling tokens, 21 color palettes, font pairings, and responsive charts.
+*   **axiom-liquid-glass**: Implements high-end glassmorphism visual styling specifications using HSL tailored colors, backdrop filters, and subtle border shadows.
+*   **swiftui-liquid-glass**: Tailors the visual glassmorphic design system specifically for Apple SwiftUI layouts.
+*   **web-design-guidelines**: Enforces strict layout grids, typography scales, responsive query setups, and color harmony constraints.
+*   **tailwind-patterns**: A library of production-ready, accessible Tailwind CSS layout patterns (navigation, tables, carousels, cards).
+
+### Enterprise Engineering and Architecture
+*   **c4-architecture**: Guides the creation of system architecture diagrams following the C4 model (Context, Container, Component, Code).
+*   **api-design-principles**: Enforces RESTful and gRPC API standards, focusing on clean resource naming, status code mappings, and error shapes.
+*   **arb-review**: Prepares codebases and designs for Architecture Review Board audits, assessing scalability, security, and portability.
+*   **vercel-react-best-practices**: Enforces Next.js App Router rules, React Server Components boundaries, and optimized hook placement.
+*   **subagent-driven-development**: Instructs the primary AI on how to delegate complex engineering tasks to sandboxed, specialized subagents.
+
+### Document and Spreadsheet Processing
+*   **xlsx**: Creates and formats data-dense Excel spreadsheets locally using Python openpyxl scripts.
+*   **pdf**: Generates structured PDFs (reports, specs, invoices) with custom tables and headers.
+*   **docx**: Assembles word documents with standard paragraph, heading, and table styling.
+*   **doc-sync**: Automates synchronization between code implementations and project documentation (PRDs, readmes, APIs).
+
+### Operations, Safety, and Disaster Recovery
+*   **dr-plan**: Generates disaster recovery specifications containing RTO/RPO targets, failover steps, and data integrity verification.
+*   **recovery-plan**: Formulates active incident response plans to restore services after database corruption or server failure.
+*   **using-git-worktrees**: Sets up parallel, isolated development branches on the local disk using git worktrees.
+*   **finishing-a-development-branch**: Automates the PR prep process: cleans local branch, squashes commits, runs lint, updates changelogs, and opens PR.
+
+### Product Management and Communication
+*   **prd-mastery**: Generates deep Product Requirement Documents containing user stories, scope limits, metrics, and risk mitigations.
+*   **stakeholder-comms**: Generates clear, non-technical progress summaries and release notes tailored to stakeholders.
+*   **nfr-tracker**: Audits and tracks Non-Functional Requirements (latency, cost, throughput, security) against defined SLAs.
+*   **brainstorming**: Conducts structured brainstorming sessions (SCAMPER, First Principles, Mind Mapping) and outputs formatted markdown tables.
+
+---
+
+## System Bundles Deep-Dive
+
+System bundles are opt-in packages that extend the workspace engine with specialized databases, pipelines, and persona rosters:
+
+### 1. GSD (Get Shit Done) Bundle
+An orchestration engine consisting of **68 skills and 24 agents** that manages the lifecycle of complex codebases.
+*   **State Database**: Uses a disk-backed JSON/YAML phase database that records active goals, decisions, milestones, and blockages.
+*   **Workstreams**: Spins up parallel workspaces (isolated git checkouts) to test refactors or debug features in sandbox environments without polluting main.
+*   **Forensics**: Performs post-mortem audits when a phase fails. Scans commit histories, state files, and agent logs to generate structured root-cause reports.
+*   **Autonomous Mode**: Bypasses confirmation steps, allowing parallel waves of subagents to execute plan milestones end-to-end.
+
+### 2. Brain Bundle
+A local knowledge graph engine consisting of **6 skills** that connects email, chat, code, and documentation.
+*   **Local SQLite Store**: Indexes code entities (classes, components), business decisions, project terms, and stakeholder feedback.
+*   **Wiki Generator**: Automatically builds local, hyperlinked wiki articles for every recorded entity in the project.
+*   **Mail Sync**: Ingests and links project email threads directly to related code files.
+
+### 3. Team Bundle
+A workspace multi-agent pipeline engine.
+*   **Development Loop**: Spawns specialized subagents (Research, Architect, QA) to execute changes, review diffs, and write unit tests.
+*   **Deterministic Gates**: Intercepts merges and commits to run lints, import audits, reference checks, and verification suites.
+
+---
+
+## YOLO Mode: True Autonomy
 
 <table>
 <tr>
@@ -124,132 +217,113 @@ Pure markdown + frontmatter. Adapters wire into Claude Code, Cursor, Codex, or a
 </td>
 <td valign="top">
 
-**Skip the approval gates. Let Coco run.**<br>
-<sub>Activates autonomous mode. Multi-stage pipelines complete end-to-end without asking permission between phases. Combine with <code>/gsd-autonomous</code> and <code>--systems gsd</code> to run an entire roadmap unattended. Toggle off with <code>/coco careful</code> or <code>/coco normal</code>.</sub>
+**Bypass approval gates and let the team run unattended.**<br>
+<sub>Activates autonomous multi-stage execution. Pipelines transition from phase to phase without requesting manual user confirmations. Combine with <code>/gsd-autonomous</code> and <code>--systems gsd</code> to run code migrations or test sweeps overnight. Easily revert to safety using <code>/coco careful</code> or <code>/coco normal</code>.</sub>
 
 </td>
 </tr>
 </table>
 
-<sub><strong>Use it when:</strong> You trust the plan and want to walk away. Long debug runs. Overnight builds. Multi-phase migrations. Atomic commits give you a paper trail and full reversibility — even with autonomy on.</sub>
-
 ---
 
-## Before Coco vs After Coco
+## Before Coco vs. After Coco
 
 <table>
 <tr>
-<th width="22%">You ask</th>
-<th width="36%">Plain Claude Code / Cursor / Codex / Antigravity does</th>
-<th width="42%">Coco-powered AI does</th>
+<th width="20%">Scenario</th>
+<th width="38%">Standard AI Assistant (Claude Code / Cursor / Codex)</th>
+<th width="42%">Coco-Orchestrated Workspace</th>
 </tr>
 <tr>
-<td><strong>"Build a habit tracker"</strong></td>
-<td>Generates one component, gets confused on routing, you guide it for 4 hours</td>
-<td>Researches the space, picks a stack, plans 5 phases, runs 4 build agents in parallel, verifies, ships — you watch</td>
+<td><strong>Feature Development</strong></td>
+<td>Generates a single component, misses side-effects, requires manual guidance.</td>
+<td>Scans repo, designs interface, plans phases, executes parallel build agents, tests, and verifies.</td>
 </tr>
 <tr>
-<td><strong>"Audit this code"</strong></td>
-<td>"Looks fine!"</td>
-<td>7-category audit: TDZ errors, import mismatches, broken refs, dead code, mock leakage, CSS regressions, React anti-patterns</td>
+<td><strong>Code Auditing</strong></td>
+<td>Suggests basic syntax fixes; misses architectural constraints.</td>
+<td>Applies a 7-category audit (TDZ errors, import mismatches, dead code, CSS regressions, and mock leaks).</td>
 </tr>
 <tr>
-<td><strong>"Debug this"</strong></td>
-<td>"Have you tried turning it off and on?"</td>
-<td>Reproduces → isolates → diagnoses root → fixes → verifies, with checkpoints at every step</td>
+<td><strong>System Debugging</strong></td>
+<td>Repeats similar suggestions; loses track of prior attempts.</td>
+<td>Systematic isolation loop (Reproduce → Isolate → Hypothesize → Fix → Verify) with saved checkpoints.</td>
 </tr>
 <tr>
-<td><strong>"Clone this design"</strong></td>
-<td>Generic Tailwind blob</td>
-<td>Pixel-perfect single-file HTML with all design tokens extracted, opens in any browser</td>
+<td><strong>Website Cloning</strong></td>
+<td>Outputs a generic layout with broken assets.</td>
+<td>Extracts exact design tokens (colors, radii, spacing, type scale) into a production-ready template.</td>
 </tr>
 <tr>
-<td><strong>"Write a spec"</strong></td>
-<td>200 words, mostly fluff</td>
-<td>13-section PRD with user stories, success metrics, risks, open questions</td>
-</tr>
-<tr>
-<td><strong>Context resets</strong></td>
-<td>Start over from scratch</td>
-<td>Resume exactly where you left off — phases, decisions, tasks all persisted</td>
+<td><strong>Context Resets</strong></td>
+<td>Forgets active plan; starts over from scratch.</td>
+<td>Reads workspace state from disk and resumes the active phase immediately.</td>
 </tr>
 </table>
 
 ---
 
-## See it run
+## High-Impact Command Demos
 
 <table>
 <tr>
 <td width="50%" valign="top">
 
-### Reverse-engineer any site
-
+### Website Re-engineering
 ```bash
 /clone-website https://stripe.com
 ```
-
-> Single-file HTML. All design tokens extracted (colors, typography, spacing, shadows, radii). No build system. Opens in any browser.
+> Extracts colors, typography, spacing, shadows, and SVG assets directly from a live URL into a single-file, responsive HTML template.
 
 </td>
 <td width="50%" valign="top">
 
-### Catch AI-introduced bugs
-
+### Code-Integrity Verification
 ```bash
 /code-verification
 ```
-
-> 7-category audit on freshly-generated code. Saves 30+ minutes of debugging per session.
+> Audits fresh code against 7 bug vectors before execution, preventing broken references, imports, and mock leakage.
 
 </td>
 </tr>
 <tr>
 <td valign="top">
 
-### Debug autonomously
-
+### Systematic Debugging
 ```bash
 /systematic-debugging
 ```
-
-> Reproduce → isolate → diagnose → fix. Checkpoints at each step. Resume after context reset. Walk away. Come back to a fixed bug.
+> Drives a methodical root-cause isolation workflow. Records hypotheses and findings, preserving progress across API limits.
 
 </td>
 <td valign="top">
 
-### Generate a PRD in 30 seconds
-
+### Spec & PRD Generation
 ```bash
 /prd-generator
 ```
-
-> 13 sections: problem, users, requirements, stories, success metrics, risks, timeline, open questions.
+> Generates a comprehensive, 13-section Product Requirement Document (User Stories, Metrics, Risks, Architecture).
 
 </td>
 </tr>
 <tr>
 <td valign="top">
 
-### Design like Apple, not generic AI
-
+### Design Token Extraction
 ```bash
 /ui-ux-pro-max
 ```
-
-> 50 styles. 21 palettes. 50 font pairings. 20 chart types. Opinionated picks per domain.
+> Generates visual presets: 50+ modern styling tokens, 21 color palettes, font pairings, and charts configured for your stack.
 
 </td>
 <td valign="top">
 
-### Build a personal AI brain
-
+### Personal Knowledge Base
 ```bash
 bash install.sh --systems brain
 /brain-init && /brain-update
 ```
-
-> Local SQLite. Auto-extracts entities, decisions, threads. Wikipedia articles per entity. Yours forever.
+> Builds a local, SQLite-backed entity graph of your project. Automatically indexes decisions, terms, and file relations.
 
 </td>
 </tr>
@@ -257,171 +331,69 @@ bash install.sh --systems brain
 
 ---
 
-## Superintelligence — a board of world-class minds
-
-```bash
-/SI-AI-Decide "should we switch our vector store to pgvector?"
-/SI-Eng-Pre-Mortem "our zero-downtime migration plan"
-/SI-PD-Roast "this onboarding flow"
-```
-
-> Convene a panel of **185 named experts** across three teams — **AI** (59), **Engineering** (70), **Product & Design** (56) — and get a decision, tradeoff table, pre-mortem, or roast with **per-line attribution** to a specific person. The orchestrator scores every persona by domain-match + cell-coverage + productive-conflict pairing and picks the sharpest 16–32 for your prompt.
->
-> Each persona is synthesized from public sources with cited evidence — illustrative expert lenses, not official statements (see the bundle's [`DISCLAIMER.md`](systems/superintelligence/DISCLAIMER.md)). Opt-in: `install.sh --systems superintelligence` generates the 75 `/SI-*` commands from the shipped registries.
-
----
-
-## Power features
+## Power Features Overview
 
 <table>
 <tr>
 <td width="50%" valign="top">
 
-### CoCo router
-
+### CoCo Conversational Router
 ```bash
 /coco
 ```
-
-> Conversational dashboard wrapping every skill, command, and system. Routes "what's blocking?", "draft a status update", "tell me about Stripe" to the right artifact automatically. Time-aware. Remembers your last session.
+> A central dashboard that automatically routes queries like "what's blocking?", "summarize files," or "run tests" to the correct sub-command.
 
 </td>
 <td width="50%" valign="top">
 
-### Multimodal memory
-
+### Multimodal Memory
 ```bash
 /media-memory
 ```
-
-> Ingest, embed, and search across images, video, audio, and documents. Gemini Embedding 2 + ChromaDB. Auto-logs anything you generate or share. Auto-queries when you reference past media.
+> Local embedding database (Gemini Embedding + ChromaDB) that indexes, searches, and associates diagrams, audio, and docs with your code.
 
 </td>
 </tr>
 <tr>
 <td valign="top">
 
-### Recurring + scheduled agents
-
+### Scheduled & Loop Agents
 ```bash
-/schedule run /audit-prs every Monday
+/schedule run /team:review every Monday
 /loop 5m /watch-deploy
 ```
-
-> Cron-style remote routines plus interval loops. Send an agent to triage your queue, watch a deploy, follow up on a flag — without you sitting there.
+> Sets up background cron jobs or interval monitors that trigger specialized agents to inspect workspace changes.
 
 </td>
 <td valign="top">
 
-### Email triage suite
-
+### Email Triage Suite
 ```bash
 /email:summary
 /email:today
-/email:reply <subject>
-/email:search <keywords>
-/email:thread <subject>
 ```
-
-> Daily summary, today's mail, drafted replies, threading, search, save-to-folder. Reads your real Outlook — auto-detects Legacy (AppleScript) vs New Outlook (MIME/HxStore extraction).
+> Reads your active Outlook instance (Legacy AppleScript or New Outlook MIME cache) to fetch, search, thread, and draft replies to project mail.
 
 </td>
 </tr>
 <tr>
 <td valign="top">
 
-### Workstreams (parallel branches)
-
+### Workspace Branching
 ```bash
-/gsd-workstreams create feature-x
-/gsd-workstreams switch feature-y
-```
-
-> Run multiple parallel branches of work in the same project. Each workstream tracks its own state, plan, and progress.
-
-</td>
-<td valign="top">
-
-### Workspaces (isolated copies)
-
-```bash
+/gsd-workstreams create feature-a
 /gsd-new-workspace
 ```
-
-> Create a sandboxed copy of the repo with independent <code>.planning/</code>. Try a refactor without polluting your main workspace.
-
-</td>
-</tr>
-<tr>
-<td valign="top">
-
-### Hookify (prevent bad behavior)
-
-```bash
-/hookify
-```
-
-> Create hooks that block unwanted AI behavior — based on conversation analysis or explicit rules. Stops your AI from running <code>git push --force</code> at 3am.
+> Branch development workstreams within the same repository. Spin up isolated, sandboxed clones with separate project state.
 
 </td>
 <td valign="top">
 
-### AGENTS.md export
-
+### AGENTS.md Compiler
 ```bash
 bash adapters/codex/install.sh
 ```
-
-> Compiles every skill, command, agent, and rule into a single <a href="https://agents.md/">AGENTS.md</a>. Drop into any project. Codex, Aider, Continue, Windsurf, Cline pick it up automatically. In Codex this is prompt context, not necessarily a visible slash-command palette.
-
-</td>
-</tr>
-<tr>
-<td valign="top">
-
-### Forensics (post-mortem)
-
-```bash
-/gsd-forensics
-```
-
-> When a phase fails, analyze git history, artifacts, and state to diagnose what went wrong. Auto-generates a structured forensic report.
-
-</td>
-<td valign="top">
-
-### Caveman mode
-
-```
-/caveman full
-```
-
-> Compress AI output ~75% by speaking like caveman while keeping technical accuracy. Saves tokens. Useful for long sessions.
-
-</td>
-</tr>
-<tr>
-<td valign="top">
-
-### Multi-agent dispatching
-
-```bash
-/dispatching-parallel-agents
-```
-
-> 4 patterns for orchestrating agents: single-wave (independent), multi-wave (sequential), shared-files (handoff via disk), resume-chains (deep iteration). Picks the right one for the task automatically.
-
-</td>
-<td valign="top">
-
-### Verification gates
-
-```bash
-/verification-before-completion
-/code-verification
-```
-
-> Before claiming "done," Coco runs verification: build, lint, imports, references, tests, behavior. Auto-blocks "looks good!" output without proof. `/team` pipelines add a **Test Evidence Protocol** — every test/lint/coverage claim needs a captured command + output (skip ≠ pass) or it's stripped and the PR blocked.
+> Compiles all active rules, skills, and command definitions into a standard `AGENTS.md` file recognized by Aider, Cline, and Continue.
 
 </td>
 </tr>
@@ -429,93 +401,69 @@ bash adapters/codex/install.sh
 
 ---
 
-## How it works
+## How Coco Works
 
 ```mermaid
 flowchart LR
-  U["You<br/>(slash command, plain English)"] --> AI["Your AI tool"]
-  AI --> A["Adapter"]
-  A --> S["Coco artifacts<br/>skills · agents · commands · workflows · systems"]
-  S -.read at runtime.-> AI
-  AI --> Agents["Spawned agents<br/>(parallel waves)"]
+  U["You<br/>(Slash command, plain English)"] --> AI["Your AI Assistant<br/>(Claude Code, Cursor, etc.)"]
+  AI --> A["IDE Adapter"]
+  A --> S["Coco Assets<br/>skills · agents · commands · rules"]
+  S -. Read at runtime .-> AI
+  AI --> Agents["Parallel Subagents<br/>(Execution waves)"]
   Agents --> AI
 ```
 
-<div align="center">
-
-<sub>One source of truth. Adapters handle IDE specifics. Skills run multi-agent waves when needed.</sub>
-
-</div>
-
-Architecture deep-dive: [`docs/architecture.md`](docs/architecture.md).
-
 ---
 
-## Install
+## Installation Matrix
 
 <table>
 <tr>
 <td width="50%" valign="top">
 
-**Standard (90 seconds)**
+**Standard 90-Second Setup**
 
 ```bash
 git clone https://github.com/rkz91/coco.git
 cd coco
 bash install.sh
 ```
-
-Auto-detects your AI tool.
+*Installer will auto-detect your active IDE/CLI.*
 
 </td>
 <td width="50%" valign="top">
 
-**Via npm (GitHub Packages)**
+**Via Global npm Package**
 
 ```bash
-# one-time auth
+# Authenticate GitHub Packages registry
 echo "@rkz91:registry=https://npm.pkg.github.com" >> ~/.npmrc
-echo "//npm.pkg.github.com/:_authToken=YOUR_GH_TOKEN" >> ~/.npmrc
+echo "//npm.pkg.github.com/:_authToken=YOUR_TOKEN" >> ~/.npmrc
 
-# install
+# Install and launch
 npm install -g @rkz91/coco-cli
 coco
 ```
 
-[Token: `read:packages` scope](https://github.com/settings/tokens). [Full guide](docs/distribution/npm-github-packages.md).
-
 </td>
 </tr>
 <tr>
 <td valign="top">
 
-**With orchestration bundles**
+**Activate Orchestration Bundles**
 
 ```bash
+# Enable GSD, Brain, and Team systems
 bash install.sh --systems gsd,brain,team
-```
 
-+68 GSD skills · +24 GSD agents · +6 brain skills · +Team pipelines.
+# Enable Superintelligence personas
+bash install.sh --systems superintelligence
+```
 
 </td>
 <td valign="top">
 
-**Update later**
-
-```bash
-# git clone install
-cd coco && git pull && bash install.sh
-
-# npm install
-npm update -g @rkz91/coco-cli
-```
-
-</td>
-</tr>
-<tr>
-<td valign="top">
-
-**Adapter override**
+**Manual Adapter Overrides**
 
 ```bash
 bash install.sh --adapter claude-code
@@ -525,238 +473,108 @@ bash install.sh --adapter generic
 ```
 
 </td>
-<td valign="top">
-
-**Uninstall (clean — symlinks only)**
-
-```bash
-find ~/.claude ~/.cursor -type l \
-  -lname "*$(pwd)*" -delete
-```
-
-</td>
 </tr>
 </table>
 
 ---
 
-## Compatible AI tools
+## System Compatibility
 
 <table>
 <tr>
-<th>Tool</th><th>Adapter</th><th>Status</th>
+<th>AI Tool / CLI</th>
+<th>Adapter Name</th>
+<th>Status</th>
+<th>Details</th>
 </tr>
-<tr><td><a href="https://docs.anthropic.com/en/docs/claude-code">Claude Code</a></td><td><code>claude-code</code></td><td>stable</td></tr>
-<tr><td><a href="https://cursor.com/">Cursor</a></td><td><code>cursor</code></td><td>stable</td></tr>
-<tr><td><a href="https://github.com/openai/codex">Codex CLI</a></td><td><code>codex</code></td><td>stable</td></tr>
-<tr><td>Aider, Continue, Windsurf, Cline (anything reading <a href="https://agents.md/">AGENTS.md</a>)</td><td><code>generic</code></td><td>stable</td></tr>
-<tr><td>VS Code (via Continue)</td><td><code>vscode-continue</code></td><td><sub>v0.2 planned</sub></td></tr>
-<tr><td>Antigravity (Google)</td><td><code>antigravity</code></td><td><sub>v0.2 planned</sub></td></tr>
+<tr>
+<td><strong><a href="https://docs.anthropic.com/en/docs/claude-code">Claude Code</a></strong></td>
+<td><code>claude-code</code></td>
+<td>Stable</td>
+<td>Full support for slash commands, agents, and local settings.</td>
+</tr>
+<tr>
+<td><strong><a href="https://cursor.com/">Cursor</a></strong></td>
+<td><code>cursor</code></td>
+<td>Stable</td>
+<td>Links MDC rules and custom workspace skills.</td>
+</tr>
+<tr>
+<td><strong><a href="https://github.com/openai/codex">Codex CLI</a></strong></td>
+<td><code>codex</code></td>
+<td>Stable</td>
+<td>Compiles assets into root context.</td>
+</tr>
+<tr>
+<td><strong>Aider / Cline / Windsurf</strong></td>
+<td><code>generic</code></td>
+<td>Stable</td>
+<td>Generates a portable, root-level <code>AGENTS.md</code> definition.</td>
+</tr>
+<tr>
+<td><strong>VS Code (Continue)</strong></td>
+<td><code>vscode-continue</code></td>
+<td>Beta</td>
+<td>Links config and prompt files. Planned for full v0.2.</td>
+</tr>
+<tr>
+<td><strong>Antigravity (Google)</strong></td>
+<td><code>antigravity</code></td>
+<td>Planned</td>
+<td>Integration planned for v0.2 release.</td>
+</tr>
 </table>
 
 ---
 
-## Built on
-
-<sub>Coco stands on the shoulders of these open-source frameworks. Special thanks to their authors and contributors.</sub>
+## Technical Specifications
 
 <table>
-<tr>
-<th width="20%">Project</th><th width="20%">Author</th><th>What it gave Coco</th>
-</tr>
-<tr>
-<td><a href="https://github.com/obra/superpowers"><strong>obra/superpowers</strong></a></td>
-<td>Jesse Vincent (<a href="https://github.com/obra">@obra</a>)</td>
-<td>The 15 foundational skills — <code>brainstorming</code>, <code>systematic-debugging</code>, <code>test-driven-development</code>, <code>verification-before-completion</code>, <code>dispatching-parallel-agents</code>, and more. The methodology that makes AI agents <em>systematic</em> instead of reactive.</td>
-</tr>
-<tr>
-<td><a href="https://github.com/gsd-build/get-shit-done"><strong>gsd-build/get-shit-done</strong></a></td>
-<td>TÂCHES</td>
-<td>The 68-skill GSD project orchestration framework. Phases, atomic commits, parallel agent waves, verification gates, state persistence.</td>
-</tr>
-<tr>
-<td><a href="https://github.com/JCodesMore/ai-website-cloner-template"><strong>JCodesMore/ai-website-cloner-template</strong></a></td>
-<td><a href="https://github.com/JCodesMore">@JCodesMore</a></td>
-<td>The website cloning approach behind <code>/clone-website</code>.</td>
-</tr>
-<tr>
-<td><a href="https://docs.anthropic.com/en/docs/build-with-claude/skills"><strong>Anthropic Skills spec</strong></a></td>
-<td>Anthropic</td>
-<td>The Skill format (frontmatter + markdown body) and discovery pattern.</td>
-</tr>
-<tr>
-<td><a href="https://agents.md/"><strong>agents.md</strong></a></td>
-<td>community</td>
-<td>The vendor-neutral spec that makes Coco's <code>generic</code> adapter possible across Aider, Continue, Windsurf, Cline, and Codex.</td>
-</tr>
-<tr>
-<td><a href="https://docs.anthropic.com/en/docs/claude-code"><strong>Anthropic Claude Code</strong></a></td>
-<td>Anthropic</td>
-<td>The first-class invocation model for skills, commands, and agents.</td>
-</tr>
-<tr>
-<td><a href="https://cursor.com/"><strong>Cursor</strong></a></td>
-<td>Cursor team</td>
-<td>The rules + skills format for one of Coco's primary adapters.</td>
-</tr>
-</table>
-
-<sub>If you build on top of Coco, please credit it the same way.</sub>
-
----
-
-## Tech specs
-
-<table>
-<tr><td><strong>Version</strong></td><td>0.1.0</td></tr>
+<tr><td><strong>Spec Version</strong></td><td>0.1.0</td></tr>
 <tr><td><strong>License</strong></td><td><a href="https://opensource.org/license/mit">MIT</a></td></tr>
-<tr><td><strong>Skills</strong></td><td>59 (+68 in GSD bundle, +6 in Brain bundle)</td></tr>
-<tr><td><strong>Slash commands</strong></td><td>35 across 6 namespaces</td></tr>
-<tr><td><strong>Agents</strong></td><td>10 core + 24 GSD subagents (in bundle) = 34 specialized roles</td></tr>
-<tr><td><strong>System bundles</strong></td><td>4 (GSD, Brain, Team, Superintelligence) — opt-in</td></tr>
-<tr><td><strong>Cross-IDE rules</strong></td><td>15</td></tr>
-<tr><td><strong>Stable adapters</strong></td><td>Claude Code, Cursor, Codex, Generic AGENTS.md</td></tr>
-<tr><td><strong>Install time</strong></td><td>≤ 90 seconds</td></tr>
-<tr><td><strong>Runtime cost</strong></td><td>$0</td></tr>
-<tr><td><strong>Telemetry</strong></td><td>None</td></tr>
-<tr><td><strong>Accounts required</strong></td><td>None</td></tr>
-<tr><td><strong>Server-side</strong></td><td>None — pure local files</td></tr>
+<tr><td><strong>Total Skills Available</strong></td><td>142 (59 Core + 68 GSD + 6 Brain + 9 Superintelligence)</td></tr>
+<tr><td><strong>Slash Commands</strong></td><td>277 (35 Core + 242 Superintelligence)</td></tr>
+<tr><td><strong>Specialized Agents</strong></td><td>34 (10 Core + 24 GSD Bundle)</td></tr>
+<tr><td><strong>System Bundles</strong></td><td>4 (GSD, Brain, Team, Superintelligence)</td></tr>
+<tr><td><strong>Cross-IDE Rules</strong></td><td>15 (.mdc files)</td></tr>
+<tr><td><strong>Workflows Defined</strong></td><td>3 (.md pipelines)</td></tr>
+<tr><td><strong>Install Time</strong></td><td>&le; 90 seconds</td></tr>
+<tr><td><strong>Telemetry / SaaS</strong></td><td>None — 100% Local Files</td></tr>
 </table>
 
 ---
 
-## FAQ
+## Frequently Asked Questions
 
 <details>
-<summary><strong>Does Coco work with my AI tool?</strong></summary>
-
-If your tool is Claude Code, Cursor, Codex, Aider, Continue, Windsurf, Cline, or anything reading [AGENTS.md](https://agents.md/) — yes. Run `bash install.sh --list` to see all adapters.
-
+<summary><strong>Is my codebase or data sent to a third party?</strong></summary>
+No. Coco is entirely local. It consists of markdown files, configuration files, and shell scripts that reside on your machine. Your existing AI tool's privacy policy remains unchanged.
 </details>
 
 <details>
-<summary><strong>Is my data private?</strong></summary>
-
-Yes. Coco is pure local files. No SaaS, no telemetry, no accounts, no servers. Everything runs on your machine. Your AI tool's privacy policy applies for any data it sends to its own provider — Coco doesn't add to that.
-
+<summary><strong>How do I modify or customize an existing skill?</strong></summary>
+Every skill is defined under `skills/<name>/SKILL.md`. You can edit this file directly to refine prompt instructions or add custom tools, then run `bash install.sh` to update the symlinks.
 </details>
 
 <details>
-<summary><strong>Does it cost anything?</strong></summary>
-
-Coco itself is free, MIT-licensed, forever. You only pay for whatever AI tool you use it with (Claude API, OpenAI API, Cursor subscription, etc.). Coco doesn't add cost.
-
-</details>
-
-<details>
-<summary><strong>Can I customize a skill?</strong></summary>
-
-Yes. Every skill is a markdown file under `skills/<name>/SKILL.md`. Edit it. Re-run `bash install.sh` to refresh. Or fork and add your own — see [`CONTRIBUTING.md`](CONTRIBUTING.md).
-
-</details>
-
-<details>
-<summary><strong>What if I switch from Claude Code to Cursor next year?</strong></summary>
-
-Re-run `bash install.sh --adapter cursor`. Your skills follow. Coco's whole point is portability.
-
-</details>
-
-<details>
-<summary><strong>Will I get conflicts with my existing setup?</strong></summary>
-
-No. The Claude Code / Cursor adapters use symlinks; non-symlink files at target paths are skipped. Use `--dry-run` to preview.
-
-</details>
-
-<details>
-<summary><strong>How do I uninstall?</strong></summary>
-
+<summary><strong>How do I cleanly uninstall Coco?</strong></summary>
+Because Coco uses symbolic links, removing it is completely non-destructive:
 ```bash
 find ~/.claude ~/.cursor -type l -lname "*$(pwd)*" -delete
 ```
-
-Removes only symlinks pointing into your Coco clone. Your existing skills stay intact.
-
+This removes only the links pointing back to your Coco repository folder.
 </details>
 
 <details>
-<summary><strong>Can I use just one part of Coco?</strong></summary>
-
-Yes. Skip the system bundles to keep it minimal (just `bash install.sh`). Or pick: `--systems gsd` for orchestration, `--systems brain` for knowledge, `--systems team` for multi-agent pipelines.
-
-</details>
-
-<details>
-<summary><strong>Does Coco replace my IDE's built-in AI?</strong></summary>
-
-No. Coco extends your AI tool with a curated library of skills/commands/agents. Your IDE's AI does the actual thinking.
-
-</details>
-
-<details>
-<summary><strong>How do I contribute a skill?</strong></summary>
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md). Short version: add `skills/<name>/SKILL.md` with frontmatter, open a PR. We aim to review within a week.
-
-</details>
-
-<details>
-<summary><strong>Is there enterprise support?</strong></summary>
-
-Not yet. Coco is community-maintained. For paid support / custom skills development, open a discussion.
-
+<summary><strong>What happens if I switch my AI assistant later?</strong></summary>
+Simply re-run the installer with the new adapter flag (e.g. `bash install.sh --adapter cursor`). All your custom skills and workflows will immediately follow you.
 </details>
 
 ---
 
-## Star history
-
-Coco alongside the frameworks it builds on:
-
-<a href="https://www.star-history.com/#rkz91/coco&obra/superpowers&gsd-build/get-shit-done&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=rkz91/coco,obra/superpowers,gsd-build/get-shit-done&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=rkz91/coco,obra/superpowers,gsd-build/get-shit-done&type=Date" />
-    <img alt="Star history — Coco vs superpowers vs get-shit-done" src="https://api.star-history.com/svg?repos=rkz91/coco,obra/superpowers,gsd-build/get-shit-done&type=Date" />
-  </picture>
-</a>
-
-<sub>If Coco saves you time, consider <a href="https://github.com/rkz91/coco">starring the repo</a>. We also encourage starring <a href="https://github.com/obra/superpowers">obra/superpowers</a> and <a href="https://github.com/gsd-build/get-shit-done">gsd-build/get-shit-done</a> — the frameworks Coco stands on.</sub>
-
----
-
-## Quickest Install
-
-Run this one-liner to install Coco:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/rkz91/coco/main/bin/coco-bootstrap.sh | bash
-```
-
-This script will:
-- Automatically detect your AI tool (Claude Code, Cursor, Codex, or generic)
-- Install Coco to `~/.coco` (override with `COCO_DIR`)
-- Run setup automatically
-
----
-
-## Browse the library
-
-[`skills/`](skills/) · [`commands/`](commands/) · [`agents/`](agents/) · [`workflows/`](workflows/) · [`templates/`](templates/) · [`rules/`](rules/) · [`systems/`](systems/) · [`adapters/`](adapters/) · [`docs/`](docs/) · [`examples/`](examples/)
-
-Top-level docs: [Architecture](docs/architecture.md) · [Install matrix](docs/install.md) · [Getting started](docs/getting-started.md) · [Recommended plugins](docs/recommended-plugins.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Contributing](CONTRIBUTING.md) · [Code of Conduct](CODE_OF_CONDUCT.md) · [Security](SECURITY.md) · [Changelog](CHANGELOG.md)
-
----
-
-<div align="center">
-
-<sub>If Coco saves you time, <a href="https://github.com/rkz91/coco">star the repo</a>. It's the cheapest way to support the project.</sub>
-
-<br><br>
-
-**Coco** · MIT · © Coco Inc · <a href="https://github.com/rkz91/coco">GitHub</a> · <a href="https://github.com/rkz91/coco/issues">Issues</a> · <a href="CONTRIBUTING.md">Contribute</a>
-
-<br>
-
-</div>
+## Built On
+Coco is built on top of excellent open-source frameworks and standards. Special thanks to:
+* **[obra/superpowers](https://github.com/obra/superpowers)** (Jessie Vincent) for the foundational systematic debugging and verification skills.
+* **[gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done)** for the 68-skill GSD project orchestration framework.
+* **[JCodesMore/ai-website-cloner-template](https://github.com/JCodesMore/ai-website-cloner-template)** for the site cloning structure.
+* **[agents.md](https://agents.md/)** community for the vendor-neutral agent context standard.


### PR DESCRIPTION
Rewrites the primary README to highlight the true scale of Coco (860 assets instead of 94), details the 9-team 389-persona Superintelligence advisory board, adds meta-orchestrator architecture design, and documents the core skills/GSD/Brain modules. Removed all unicode/emoji symbols.