### PR TITLE
feat(readme): add hero demo GIF of a real /SI-Decide --debate run

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Free | MIT License | 90-Second Onboarding
 
 </div>
 
+<p align="center">
+  <img src="assets/demo.gif" alt="/SI-Decide --debate: a routed expert panel argues in reacting rounds before an attributed verdict" width="720" />
+</p>
+
+<div align="center"><sub><em>A real <code>/SI-Decide --debate</code> run — Coco routes an expert panel, deliberates in reacting rounds, and returns an attributed verdict with named dissent.</em></sub></div>
+
 ---
 
 <div align="center">


### PR DESCRIPTION
## What

Adds `assets/demo.gif` and embeds it under the hero (right after the badges/nav), with a one-line caption.

The GIF is a **real** Claude Code `/SI-Decide --debate "sunset the v1 API in 90 days or support both versions for a year?"` run, captured live via asciinema and rendered with agg:

- `$ claude` → the slash command → **Panel Composition** roster
- reacting rounds (Round 1 / Round 2) with named personas
- an attributed **Verdict** with **Named dissent — DHH (Engineering)** and **Minority dissent — Geoffrey Moore (Strategy), Nick Mehta (GTM)**

No transcript content was fabricated or hand-edited. Only scroll pacing and a 2s idle cap were applied so the multi-minute run compresses to ~16s. Final asset: **8.1MB**, ~16s.

Made with [Cursor](https://cursor.com)